### PR TITLE
Expire should also return errors when expiration is equal to 0 seconds.

### DIFF
--- a/util/expire.go
+++ b/util/expire.go
@@ -29,7 +29,7 @@ func GetExpireAt(leaderboardPublicID string) (int64, error) {
 		startTimestamp, _ := strconv.ParseInt(substrings[1], 10, 32)
 		endTimestamp, _ := strconv.ParseInt(substrings[2], 10, 32)
 		durationInSeconds := endTimestamp - startTimestamp
-		if durationInSeconds < 0 {
+		if durationInSeconds <= 0 {
 			return -1, &InvalidDurationError{leaderboardPublicID, durationInSeconds}
 		}
 		return endTimestamp + durationInSeconds, nil
@@ -46,7 +46,7 @@ func GetExpireAt(leaderboardPublicID string) (int64, error) {
 			return -1, err
 		}
 		durationInSeconds := endTime.Sub(startTime)
-		if durationInSeconds.Seconds() < 0 {
+		if durationInSeconds.Seconds() <= 0 {
 			return -1, &InvalidDurationError{leaderboardPublicID, int64(durationInSeconds.Seconds())}
 		}
 		return endTime.Add(durationInSeconds).Unix(), nil

--- a/util/expire_test.go
+++ b/util/expire_test.go
@@ -72,6 +72,13 @@ var _ = Describe("Expires Helper", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("has invalid duration -86400"))
 		})
+
+		It("should return error if duration is 0", func() {
+			exp, err := util.GetExpireAt("leaderboard_from20201010to20201010")
+			Expect(exp).To(BeEquivalentTo(-1))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has invalid duration 0"))
+		})
 	})
 
 	Describe("Unix Timestamp expiration", func() {
@@ -92,6 +99,14 @@ var _ = Describe("Expires Helper", func() {
 			Expect(exp).To(BeEquivalentTo(-1))
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("has invalid duration -86400"))
+		})
+
+		It("should get invalid expiration if same timestamps", func() {
+			start := time.Now()
+			exp, err := util.GetExpireAt(fmt.Sprintf("leaderboard_from%dto%d", start.Unix(), start.Unix()))
+			Expect(exp).To(BeEquivalentTo(-1))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has invalid duration 0"))
 		})
 	})
 


### PR DESCRIPTION
If expire was equal to 0, podium was returning a non intuitive error (redis: error nil). This commit fixes it.
