### PR TITLE
Added a new query parameter for GetAroundMe

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -37,7 +37,7 @@ var _ = Describe("App", func() {
 			Expect(expected).To(Equal("WORKING"))
 		})
 
-		It("Should faild if configuration file does not exist", func() {
+		It("Should fail if configuration file does not exist", func() {
 			app, err := api.GetApp("127.0.0.1", 9999, "../config/invalid.yaml", false, false, logger)
 			Expect(app).To(BeNil())
 			Expect(err).To(HaveOccurred())

--- a/api/leaderboard.go
+++ b/api/leaderboard.go
@@ -354,6 +354,11 @@ func GetAroundMemberHandler(app *App) func(c echo.Context) error {
 		if order == "" || (order != "asc" && order != "desc") {
 			order = "desc"
 		}
+		getLastIfNotFound := false
+		getLastIfNotFoundStr := c.QueryParam("getLastIfNotFound")
+		if getLastIfNotFoundStr != "" && getLastIfNotFoundStr == "true" {
+			getLastIfNotFound = true
+		}
 
 		leaderboardID := c.Param("leaderboardID")
 		memberPublicID := c.Param("memberPublicID")
@@ -366,7 +371,7 @@ func GetAroundMemberHandler(app *App) func(c echo.Context) error {
 		status := 404
 		err = WithSegment("Model", c, func() error {
 			l := leaderboard.NewLeaderboard(app.RedisClient, leaderboardID, pageSize, lg)
-			members, err = l.GetAroundMe(memberPublicID, order)
+			members, err = l.GetAroundMe(memberPublicID, order, getLastIfNotFound)
 			if err != nil && strings.HasPrefix(err.Error(), notFoundError) {
 				app.AddError()
 				status = 404

--- a/api/leaderboard.go
+++ b/api/leaderboard.go
@@ -356,7 +356,7 @@ func GetAroundMemberHandler(app *App) func(c echo.Context) error {
 		}
 		getLastIfNotFound := false
 		getLastIfNotFoundStr := c.QueryParam("getLastIfNotFound")
-		if getLastIfNotFoundStr != "" && getLastIfNotFoundStr == "true" {
+		if getLastIfNotFoundStr == "true" {
 			getLastIfNotFound = true
 		}
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -416,6 +416,11 @@ Podium API
     * if set to asc, will treat the ranking with ascending scores (less is best)
     * e.g. `GET /l/:leaderboardID/members/:memberPublicID/around?pageSize=10?order=asc`
     * defaults to "desc"
+  * getLastIfNotFound=[true|false]
+    * if set to true, will treat members not in ranking as being in last position
+    * if set to false, will return 404 when the member is not in the ranking
+    * e.g. `GET /l/:leaderboardID/members/:memberPublicID/around?getLastIfNotFound=true`
+    * defaults to "false"
 
   Gets a list of members with ranking around that of the specified member within a leaderboard.
 

--- a/leaderboard/leaderboard_test.go
+++ b/leaderboard/leaderboard_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Leaderboard Model", func() {
 				_, err := testLeaderboard.SetMemberScore("member_"+strconv.Itoa(i), 1234*i)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			members, err := testLeaderboard.GetAroundMe("member_20", "desc")
+			members, err := testLeaderboard.GetAroundMe("member_20", "desc", false)
 			Expect(err).NotTo(HaveOccurred())
 			firstAroundMe := members[0]
 			lastAroundMe := members[testLeaderboard.PageSize-1]
@@ -269,7 +269,7 @@ var _ = Describe("Leaderboard Model", func() {
 				_, err := testLeaderboard.SetMemberScore("member_"+strconv.Itoa(i), 1234*i)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			members, err := testLeaderboard.GetAroundMe("member_20", "asc")
+			members, err := testLeaderboard.GetAroundMe("member_20", "asc", false)
 			Expect(err).NotTo(HaveOccurred())
 			firstAroundMe := members[0]
 			lastAroundMe := members[testLeaderboard.PageSize-1]
@@ -284,7 +284,7 @@ var _ = Describe("Leaderboard Model", func() {
 				_, err := testLeaderboard.SetMemberScore("member_"+strconv.Itoa(i), 100)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			members, err := testLeaderboard.GetAroundMe("member_20", "desc")
+			members, err := testLeaderboard.GetAroundMe("member_20", "desc", false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(members)).To(Equal(testLeaderboard.PageSize))
 			firstAroundMe := members[0]
@@ -299,7 +299,7 @@ var _ = Describe("Leaderboard Model", func() {
 				_, err := testLeaderboard.SetMemberScore("member_"+strconv.Itoa(i), 100-i)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			members, err := testLeaderboard.GetAroundMe("member_2", "desc")
+			members, err := testLeaderboard.GetAroundMe("member_2", "desc", false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(members)).To(Equal(testLeaderboard.PageSize))
 			firstAroundMe := members[0]
@@ -314,7 +314,7 @@ var _ = Describe("Leaderboard Model", func() {
 				_, err := testLeaderboard.SetMemberScore("member_"+strconv.Itoa(i), 100-i)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			members, err := testLeaderboard.GetAroundMe("member_99", "desc")
+			members, err := testLeaderboard.GetAroundMe("member_99", "desc", false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(members)).To(Equal(testLeaderboard.PageSize))
 			firstAroundMe := members[0]
@@ -329,7 +329,7 @@ var _ = Describe("Leaderboard Model", func() {
 				_, err := testLeaderboard.SetMemberScore("member_"+strconv.Itoa(i), 100-i)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			members, err := testLeaderboard.GetAroundMe("member_2", "desc")
+			members, err := testLeaderboard.GetAroundMe("member_2", "desc", false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(members).To(HaveLen(10))
 			firstAroundMe := members[0]
@@ -340,7 +340,7 @@ var _ = Describe("Leaderboard Model", func() {
 
 		It("should fail if faulty redis client", func() {
 			testLeaderboard := NewLeaderboard(getFaultyRedis(logger), "test-leaderboard", 10, logger)
-			_, err := testLeaderboard.GetAroundMe("qwe", "desc")
+			_, err := testLeaderboard.GetAroundMe("qwe", "desc", false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("getsockopt: connection refused"))
 		})

--- a/leaderboard/leaderboard_test.go
+++ b/leaderboard/leaderboard_test.go
@@ -159,9 +159,8 @@ var _ = Describe("Leaderboard Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			Expect(testLeaderboard.TotalMembers()).To(Equal(10))
-			members := make([]interface{}, 1)
-			members[0] = "member_5"
-			testLeaderboard.RemoveMembers(members)
+			member := "member_5"
+			testLeaderboard.RemoveMember(member)
 			Expect(testLeaderboard.TotalMembers()).To(Equal(9))
 		})
 


### PR DESCRIPTION
This new query parameter deals with the case when the player is not
in the ranking, if the flag is enabled then the last players in the
ranking are returned instead of returning 404.

Default behavior does not change, should not break compatibility.

@cscatolini could you take a look?