### PR TITLE
LeaderboardExpiredError

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/topfreegames/podium/log"
 	"github.com/topfreegames/podium/util"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // JSON type

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/topfreegames/podium/api"
 	. "github.com/topfreegames/podium/testing"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 var _ = Describe("App", func() {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/topfreegames/podium/api"
 	"github.com/topfreegames/podium/testing"
 	"github.com/topfreegames/podium/util"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	"github.com/valyala/fasthttp"
 )
 

--- a/api/leaderboard.go
+++ b/api/leaderboard.go
@@ -17,7 +17,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/labstack/echo"
 	"github.com/topfreegames/podium/leaderboard"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 var notFoundError = "Could not find data for member"
@@ -103,7 +103,7 @@ func UpsertMemberScoreHandler(app *App) func(c echo.Context) error {
 			return nil
 		})
 		if err != nil {
-			return FailWith(500, err.Error(), c)
+			return FailWithError(err, c)
 		}
 
 		return SucceedWith(serializeMember(member, -1), c)
@@ -145,7 +145,7 @@ func IncrementMemberScoreHandler(app *App) func(c echo.Context) error {
 			return nil
 		})
 		if err != nil {
-			return FailWith(500, err.Error(), c)
+			return FailWithError(err, c)
 		}
 
 		return SucceedWith(serializeMember(member, -1), c)

--- a/api/leaderboard_test.go
+++ b/api/leaderboard_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Leaderboard Handler", func() {
 					time.Now().UTC().Add(time.Duration(-2)*time.Second).Unix(),
 					time.Now().UTC().Add(time.Duration(-1)*time.Second).Unix(),
 				),
+				fmt.Sprintf("testkey-from20180101to20180105"),
 				fmt.Sprintf(
 					"testkey-year%d",
 					time.Now().UTC().AddDate(-2, 0, 0).Year(),

--- a/api/leaderboard_test.go
+++ b/api/leaderboard_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/topfreegames/podium/api"
 	"github.com/topfreegames/podium/leaderboard"
 	. "github.com/topfreegames/podium/testing"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 var _ = Describe("Leaderboard Handler", func() {
@@ -51,6 +51,74 @@ var _ = Describe("Leaderboard Handler", func() {
 		conn.Del("testkey3")
 		conn.Del("testkey4")
 		conn.Del("testkey5")
+	})
+
+	Describe("When leaderboard has expired", func() {
+		var (
+			year, week               = time.Now().UTC().AddDate(0, 0, -14).ISOWeek()
+			lastQuarter, quarterYear = func() (int, int) {
+				quarter := int(time.Now().UTC().Month())/3 + 1
+				quarterYear := time.Now().UTC().Year()
+				if quarter-2 < 0 {
+					quarterYear--
+					quarter = 4 + (quarter - 2)
+				}
+				return quarter, quarterYear
+			}()
+			keys = []string{
+				fmt.Sprintf(
+					"testkey-from%dto%d",
+					time.Now().UTC().Add(time.Duration(-2)*time.Second).Unix(),
+					time.Now().UTC().Add(time.Duration(-1)*time.Second).Unix(),
+				),
+				fmt.Sprintf(
+					"testkey-year%d",
+					time.Now().UTC().AddDate(-2, 0, 0).Year(),
+				),
+				fmt.Sprintf("testkey-year%dweek%d", year, week),
+				fmt.Sprintf(
+					"testkey-year%dmonth%d",
+					time.Now().UTC().AddDate(0, -2, 0).Year(),
+					time.Now().UTC().AddDate(0, -2, 0).Month(),
+				),
+				fmt.Sprintf(
+					"testkey-year%dquarter0%d",
+					quarterYear,
+					lastQuarter,
+				),
+			}
+		)
+
+		checkBody := func(key, body string) {
+			var result map[string]interface{}
+			json.Unmarshal([]byte(body), &result)
+			Expect(result["success"]).To(BeFalse())
+			Expect(result["reason"]).To(
+				Equal(
+					fmt.Sprintf("Leaderboard %s has already expired", key),
+				),
+			)
+		}
+
+		It("PUT upsert score", func() {
+			payload := map[string]interface{}{"score": 100}
+			for _, k := range keys {
+				httpPath := fmt.Sprintf("/l/%s/members/memberpublicid/score", k)
+				status, body := PutJSON(a, httpPath, payload)
+				Expect(status).To(Equal(http.StatusBadRequest))
+				checkBody(k, body)
+			}
+		})
+
+		It("PATCH increment score", func() {
+			payload := map[string]interface{}{"increment": 100}
+			for _, k := range keys {
+				httpPath := fmt.Sprintf("/l/%s/members/memberpublicid/score", k)
+				status, body := PatchJSON(a, httpPath, payload)
+				Expect(status).To(Equal(http.StatusBadRequest))
+				checkBody(k, body)
+			}
+		})
 	})
 
 	Describe("Upsert Member Score", func() {

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -18,7 +18,7 @@ import (
 	"github.com/getsentry/raven-go"
 	"github.com/labstack/echo"
 	"github.com/topfreegames/podium/log"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 //NewVersionMiddleware with API version

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -12,7 +12,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/podium/api"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 var host string

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -12,7 +12,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/podium/worker"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // workerCmd represents the worker command

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 51f0b4bec9f80396d42b608957f5e7800e60233fdf03641cd42471387b252e45
-updated: 2017-11-23T18:08:11.673375212-02:00
+hash: 563478ea7c3c5ff2876dcf86baf398f394d80b6b8533d39f10b4606b9ee6f2e6
+updated: 2018-02-07T10:23:55.830730918-02:00
 imports:
 - name: github.com/buger/jsonparser
   version: f04e003e4115787c6272636780bc206e5ffad6c4
@@ -73,9 +73,10 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
 - name: github.com/newrelic/go-agent
-  version: 462a146a1270954750aac98c5b3e83dec6a9adfd
+  version: f5bce3387232559bcbe6a5f8227c4bf508dac1ba
   subpackages:
   - internal
+  - internal/cat
   - internal/jsonx
   - internal/logger
   - internal/sysinfo
@@ -122,7 +123,7 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: ab2277b1c5d15c3cba104e9cbddbdfc622df5ad8
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/spf13/afero
   version: 52e4a6cfac46163658bd4f123c49b6ee7dc75f78
   subpackages:
@@ -140,8 +141,6 @@ imports:
   version: 670c42a85b2a2215949acd943cb8f11add317e3f
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
-- name: github.com/uber-go/zap
-  version: c4939d1166b2220bb45338e21506623b4bbdec50
 - name: github.com/valyala/bytebufferpool
   version: e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7
 - name: github.com/valyala/fasthttp
@@ -150,6 +149,8 @@ imports:
   - fasthttputil
 - name: github.com/valyala/fasttemplate
   version: 3b874956e03f1636d171bda64b130f9135f42cff
+- name: go.uber.org/zap
+  version: c4939d1166b2220bb45338e21506623b4bbdec50
 - name: golang.org/x/crypto
   version: 7682e7e3945130cf3cde089834664f68afdd1523
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/topfreegames/podium
 import:
 - package: github.com/onsi/ginkgo
 - package: github.com/onsi/gomega
-- package: github.com/uber-go/zap
+- package: go.uber.org/zap
 - package: github.com/rcrowley/go-metrics
 - package: gopkg.in/bsm/ratelimit.v1
 - package: github.com/satori/go.uuid

--- a/leaderboard/leaderboard.go
+++ b/leaderboard/leaderboard.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/topfreegames/podium/util"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	redis "gopkg.in/redis.v4"
 )
 

--- a/leaderboard/leaderboard_test.go
+++ b/leaderboard/leaderboard_test.go
@@ -12,7 +12,6 @@ package leaderboard_test
 import (
 	"fmt"
 	"strconv"
-
 	"time"
 
 	"gopkg.in/redis.v4"
@@ -21,7 +20,7 @@ import (
 	. "github.com/topfreegames/podium/leaderboard"
 	"github.com/topfreegames/podium/testing"
 	"github.com/topfreegames/podium/util"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -519,7 +518,7 @@ var _ = Describe("Leaderboard Model", func() {
 		})
 
 		It("should add yearly expiration if leaderboard supports it", func() {
-			leaderboardID := "test-leaderboard-year2016"
+			leaderboardID := fmt.Sprintf("test-leaderboard-year%d", time.Now().UTC().Year())
 			friendScore := NewLeaderboard(redisClient, leaderboardID, 10, logger)
 			_, err := friendScore.SetMemberScore("dayvson", 12345, false, "")
 			Expect(err).NotTo(HaveOccurred())

--- a/log/log.go
+++ b/log/log.go
@@ -9,7 +9,7 @@
 
 package log
 
-import "github.com/uber-go/zap"
+import "go.uber.org/zap"
 
 //CM is a Checked Message like
 type CM interface {

--- a/testing/extensions.go
+++ b/testing/extensions.go
@@ -19,7 +19,7 @@ import (
 	"github.com/onsi/ginkgo/types"
 	"github.com/onsi/gomega"
 	"github.com/topfreegames/podium/api"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 //BeforeOnce runs the before each block only once

--- a/testing/logger.go
+++ b/testing/logger.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/onsi/gomega/types"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 //NewMockKV is a mock key value store

--- a/util/errors.go
+++ b/util/errors.go
@@ -20,3 +20,12 @@ type InvalidDurationError struct {
 func (e *InvalidDurationError) Error() string {
 	return fmt.Sprintf("Leaderboard %s has invalid duration %v", e.LeaderboardPublicID, e.DurationInSeconds)
 }
+
+// LeaderboardExpiredError identifies that a given key generates an already expired leaderboard
+type LeaderboardExpiredError struct {
+	LeaderboardPublicID string
+}
+
+func (e *LeaderboardExpiredError) Error() string {
+	return fmt.Sprintf("Leaderboard %s has already expired", e.LeaderboardPublicID)
+}

--- a/util/expire.go
+++ b/util/expire.go
@@ -22,17 +22,48 @@ var timestampRE = regexp.MustCompile("from([0-9]{4}[0|1][0-9][0-3][0-9])to([0-9]
 var yearlyRE = regexp.MustCompile("year([0-9]{4})$")                                                        // yearly
 var quarterRE = regexp.MustCompile("year([0-9]{4})(week|quarter|month)([0-9]+)$")                           //week, quarter, mo
 
+func checkExpireAtErrors(
+	leaderboardPublicID string, startTimestamp, endTimestamp int64,
+) (int64, error) {
+	now := time.Now().UTC().Unix()
+	durationInSeconds := endTimestamp - startTimestamp
+	if durationInSeconds <= 0 {
+		return -1, &InvalidDurationError{leaderboardPublicID, durationInSeconds}
+	}
+	expireAt := endTimestamp + durationInSeconds
+	if expireAt <= now {
+		return -1, &LeaderboardExpiredError{leaderboardPublicID}
+	}
+	return expireAt, nil
+}
+
+// WeeklyExpiration calculates the expireAt date for leaderboards with weekly format
+func WeeklyExpiration(year, week int64) time.Time {
+	dummyDate, _ := time.Parse("2006", strconv.Itoa(int(year)))
+	dummyDateYear, dummyDateWeek := dummyDate.ISOWeek()
+	startTime := dummyDate.AddDate(int(year)-dummyDateYear, 0, 1+(int(week)-dummyDateWeek)*7)
+	return startTime.AddDate(0, 0, 14)
+}
+
+// MonthlyExpiration calculates the expireAt date for leaderboards with quarterly format
+func MonthlyExpiration(startTime time.Time) time.Time {
+	return startTime.AddDate(0, 2, 0)
+}
+
+// QuarterlyExpiration calculates the expireAt date for leaderboards with quarterly format
+func QuarterlyExpiration(year, quarter int64) time.Time {
+	dummyDate, _ := time.Parse("2006", strconv.Itoa(int(year)))
+	startTime := dummyDate.AddDate(0, (int(quarter)-1)*3, 0)
+	return startTime.AddDate(0, 6, 0)
+}
+
 // GetExpireAt returns a timestamp when the key should expire or -1 if the key doesn't match any valid auto expire regexes
 func GetExpireAt(leaderboardPublicID string) (int64, error) {
 	substrings := unixRE.FindStringSubmatch(leaderboardPublicID)
 	if len(substrings) == 3 {
 		startTimestamp, _ := strconv.ParseInt(substrings[1], 10, 32)
 		endTimestamp, _ := strconv.ParseInt(substrings[2], 10, 32)
-		durationInSeconds := endTimestamp - startTimestamp
-		if durationInSeconds <= 0 {
-			return -1, &InvalidDurationError{leaderboardPublicID, durationInSeconds}
-		}
-		return endTimestamp + durationInSeconds, nil
+		return checkExpireAtErrors(leaderboardPublicID, startTimestamp, endTimestamp)
 	}
 
 	substrings = timestampRE.FindStringSubmatch(leaderboardPublicID)
@@ -52,10 +83,15 @@ func GetExpireAt(leaderboardPublicID string) (int64, error) {
 		return endTime.Add(durationInSeconds).Unix(), nil
 	}
 
+	now := time.Now().UTC().Unix()
+
 	substrings = yearlyRE.FindStringSubmatch(leaderboardPublicID)
 	if len(substrings) == 2 {
 		startTime, _ := time.Parse("2006", substrings[1])
 		endTime := startTime.AddDate(2, 0, 0)
+		if endTime.Unix() <= now {
+			return -1, &LeaderboardExpiredError{leaderboardPublicID}
+		}
 		return endTime.Unix(), nil
 	}
 
@@ -70,25 +106,23 @@ func GetExpireAt(leaderboardPublicID string) (int64, error) {
 			if err != nil {
 				return -1, err
 			}
-			endTime = startTime.AddDate(0, 2, 0)
+			endTime = MonthlyExpiration(startTime)
 		}
 
+		year, _ := strconv.ParseInt(substrings[1], 10, 32)
 		if substrings[2] == "week" {
-			year, _ := strconv.ParseInt(substrings[1], 10, 32)
 			week, _ := strconv.ParseInt(substrings[3], 10, 32)
-			dummyDate, _ := time.Parse("2006", substrings[1])
-			dummyDateYear, dummyDateWeek := dummyDate.ISOWeek()
-			startTime = dummyDate.AddDate(int(year)-dummyDateYear, 0, 1+(int(week)-dummyDateWeek)*7)
-			endTime = startTime.AddDate(0, 0, 14)
+			endTime = WeeklyExpiration(year, week)
 		}
 
 		if substrings[2] == "quarter" {
 			quarter, _ := strconv.ParseInt(substrings[3], 10, 32)
-			dummyDate, _ := time.Parse("2006", substrings[1])
-			startTime = dummyDate.AddDate(0, (int(quarter)-1)*3, 0)
-			endTime = startTime.AddDate(0, 6, 0)
+			endTime = QuarterlyExpiration(year, quarter)
 		}
 
+		if endTime.Unix() <= now {
+			return -1, &LeaderboardExpiredError{leaderboardPublicID}
+		}
 		return endTime.Unix(), nil
 	}
 

--- a/util/expire.go
+++ b/util/expire.go
@@ -76,11 +76,7 @@ func GetExpireAt(leaderboardPublicID string) (int64, error) {
 		if err != nil {
 			return -1, err
 		}
-		durationInSeconds := endTime.Sub(startTime)
-		if durationInSeconds.Seconds() <= 0 {
-			return -1, &InvalidDurationError{leaderboardPublicID, int64(durationInSeconds.Seconds())}
-		}
-		return endTime.Add(durationInSeconds).Unix(), nil
+		return checkExpireAtErrors(leaderboardPublicID, startTime.Unix(), endTime.Unix())
 	}
 
 	now := time.Now().UTC().Unix()

--- a/util/expire_test.go
+++ b/util/expire_test.go
@@ -112,13 +112,19 @@ var _ = Describe("Expires Helper", func() {
 
 	Describe("Montly expiration", func() {
 		It("should get monthly expiration", func() {
-			exp, err := util.GetExpireAt("leaderboard_year2016month01")
+			now := time.Now().UTC()
+			year := now.Year()
+			month := now.Month()
+			monthS := fmt.Sprintf("%d", month)
+			if month < 10 {
+				monthS = fmt.Sprintf("0%s", monthS)
+			}
+			exp, err := util.GetExpireAt(fmt.Sprintf("leaderboard_year%dmonth%s", year, monthS))
 			Expect(err).NotTo(HaveOccurred())
 
-			start, err := time.Parse("20060102", "20160101")
-			Expect(err).NotTo(HaveOccurred())
-
-			ts := start.AddDate(0, 2, 0).Unix()
+			startTime, _ := time.Parse("200601", fmt.Sprintf("%d%s", year, monthS))
+			end := util.MonthlyExpiration(startTime)
+			ts := end.Unix()
 			Expect(exp).To(BeEquivalentTo(ts))
 		})
 
@@ -132,28 +138,29 @@ var _ = Describe("Expires Helper", func() {
 
 	Describe("Weekly expiration", func() {
 		It("should get weekly expiration", func() {
-			exp, err := util.GetExpireAt("leaderboard_year2016week01")
+			year, week := time.Now().UTC().ISOWeek()
+			weekS := fmt.Sprintf("%d", week)
+			if week < 10 {
+				weekS = fmt.Sprintf("0%s", weekS)
+			}
+			exp, err := util.GetExpireAt(fmt.Sprintf("leaderboard_year%dweek%s", year, weekS))
 			Expect(err).NotTo(HaveOccurred())
 
-			end, err := time.Parse("20060102", "20160118")
-			Expect(err).NotTo(HaveOccurred())
-
-			ts := end.Unix()
+			twoWeeksFromNow := util.WeeklyExpiration(int64(year), int64(week))
+			ts := twoWeeksFromNow.Unix()
 			Expect(exp).To(BeEquivalentTo(ts))
 		})
 	})
 
 	Describe("Quarter expiration", func() {
 		It("should get quarter expiration", func() {
-			exp, err := util.GetExpireAt("leaderboard_year2016quarter02")
+			now := time.Now().UTC()
+			year := now.Year()
+			quarter := int(now.Month())/3 + 1
+			exp, err := util.GetExpireAt(fmt.Sprintf("leaderboard_year%dquarter0%d", year, quarter))
 			Expect(err).NotTo(HaveOccurred())
 
-			dummyDate, err := time.Parse("2006", "2016")
-			Expect(err).NotTo(HaveOccurred())
-
-			start := dummyDate.AddDate(0, 3, 0)
-			end := start.AddDate(0, 6, 0)
-
+			end := util.QuarterlyExpiration(int64(year), int64(quarter))
 			ts := end.Unix()
 			Expect(exp).To(BeEquivalentTo(ts))
 		})

--- a/util/redis.go
+++ b/util/redis.go
@@ -12,7 +12,7 @@ package util
 import (
 	"fmt"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	"gopkg.in/redis.v4"
 )
 

--- a/worker/expiration_worker.go
+++ b/worker/expiration_worker.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/topfreegames/podium/util"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	redis "gopkg.in/redis.v4"
 )
 


### PR DESCRIPTION
* New error type: LeaderboardExpiredError. Returns http.StatusBadRequest instead of http.StatusInternalServerError when trying to increment/upsert to an expired leaderboard.

* Changed path to uber's zap library (was getting errors after make setup + make test)