### PR TITLE
Feature - Multiple Members Upsert Route

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -253,7 +253,7 @@ func (app *App) configureApplication() error {
 	a.Get("/healthcheck", HealthCheckHandler(app))
 	a.Get("/status", StatusHandler(app))
 	a.Delete("/l/:leaderboardID", RemoveLeaderboardHandler(app))
-	a.Put("/l/:leaderboardID/scores", UpsertMembersScoreHandler(app))
+	a.Put("/l/:leaderboardID/scores", BulkUpsertMembersScoreHandler(app))
 	a.Put("/l/:leaderboardID/members/:memberPublicID/score", UpsertMemberScoreHandler(app))
 	a.Patch("/l/:leaderboardID/members/:memberPublicID/score", IncrementMemberScoreHandler(app))
 	a.Get("/l/:leaderboardID/members/:memberPublicID", GetMemberHandler(app))

--- a/api/app.go
+++ b/api/app.go
@@ -253,7 +253,7 @@ func (app *App) configureApplication() error {
 	a.Get("/healthcheck", HealthCheckHandler(app))
 	a.Get("/status", StatusHandler(app))
 	a.Delete("/l/:leaderboardID", RemoveLeaderboardHandler(app))
-	a.Put("/l/:leaderboardID/scores", UpsertMemberScoresHandler(app))
+	a.Put("/l/:leaderboardID/scores", UpsertMembersScoreHandler(app))
 	a.Put("/l/:leaderboardID/members/:memberPublicID/score", UpsertMemberScoreHandler(app))
 	a.Patch("/l/:leaderboardID/members/:memberPublicID/score", IncrementMemberScoreHandler(app))
 	a.Get("/l/:leaderboardID/members/:memberPublicID", GetMemberHandler(app))

--- a/api/app.go
+++ b/api/app.go
@@ -253,6 +253,7 @@ func (app *App) configureApplication() error {
 	a.Get("/healthcheck", HealthCheckHandler(app))
 	a.Get("/status", StatusHandler(app))
 	a.Delete("/l/:leaderboardID", RemoveLeaderboardHandler(app))
+	a.Put("/l/:leaderboardID/scores", UpsertMemberScoresHandler(app))
 	a.Put("/l/:leaderboardID/members/:memberPublicID/score", UpsertMemberScoreHandler(app))
 	a.Patch("/l/:leaderboardID/members/:memberPublicID/score", IncrementMemberScoreHandler(app))
 	a.Get("/l/:leaderboardID/members/:memberPublicID", GetMemberHandler(app))

--- a/api/leaderboard.go
+++ b/api/leaderboard.go
@@ -42,7 +42,7 @@ func serializeMember(member *leaderboard.Member, position int, includeTTL bool) 
 	return memberData
 }
 
-func serializeMembers(members []*leaderboard.Member, includePosition bool, includeTTL bool) []map[string]interface{} {
+func serializeMembers(members leaderboard.Members, includePosition bool, includeTTL bool) []map[string]interface{} {
 	serializedMembers := make([]map[string]interface{}, len(members))
 	for i, member := range members {
 		if includePosition {
@@ -431,7 +431,7 @@ func GetAroundMemberHandler(app *App) func(c echo.Context) error {
 			return FailWith(400, err.Error(), c)
 		}
 
-		var members []*leaderboard.Member
+		var members leaderboard.Members
 		status := 404
 		err = WithSegment("Model", c, func() error {
 			l := leaderboard.NewLeaderboard(app.RedisClient.Trace(c.StdContext()), leaderboardID, pageSize, lg)
@@ -480,7 +480,7 @@ func GetAroundScoreHandler(app *App) func(c echo.Context) error {
 			return FailWith(400, err.Error(), c)
 		}
 
-		var members []*leaderboard.Member
+		var members leaderboard.Members
 		status := 404
 		err = WithSegment("Model", c, func() error {
 			l := leaderboard.NewLeaderboard(app.RedisClient.Trace(c.StdContext()), leaderboardID, pageSize, lg)
@@ -561,7 +561,7 @@ func GetTopMembersHandler(app *App) func(c echo.Context) error {
 			return FailWith(400, err.Error(), c)
 		}
 
-		var members []*leaderboard.Member
+		var members leaderboard.Members
 		err = WithSegment("Model", c, func() error {
 			l := leaderboard.NewLeaderboard(app.RedisClient.Trace(c.StdContext()), leaderboardID, pageSize, lg)
 			members, err = l.GetLeaders(pageNumber, order)
@@ -606,7 +606,7 @@ func GetTopPercentageHandler(app *App) func(c echo.Context) error {
 			return FailWith(400, "Percentage must be a valid integer between 1 and 100.", c)
 		}
 
-		var members []*leaderboard.Member
+		var members leaderboard.Members
 		status := 400
 		err = WithSegment("Model", c, func() error {
 			l := leaderboard.NewLeaderboard(app.RedisClient.Trace(c.StdContext()), leaderboardID, defaultPageSize, lg)
@@ -657,7 +657,7 @@ func GetMembersHandler(app *App) func(c echo.Context) error {
 
 		memberIDs := strings.Split(ids, ",")
 
-		var members []*leaderboard.Member
+		var members leaderboard.Members
 		err := WithSegment("Model", c, func() error {
 			var err error
 			l := leaderboard.NewLeaderboard(app.RedisClient.Trace(c.StdContext()), leaderboardID, defaultPageSize, lg)

--- a/api/leaderboard.go
+++ b/api/leaderboard.go
@@ -54,11 +54,11 @@ func serializeMembers(members []*leaderboard.Member, includePosition bool, inclu
 	return serializedMembers
 }
 
-// UpsertMemberScoresHandler is the handler responsible for creating or updating member scores
-func UpsertMemberScoresHandler(app *App) func(c echo.Context) error {
+// UpsertMembersScoreHandler is the handler responsible for creating or updating members score
+func UpsertMembersScoreHandler(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		lg := app.Logger.With(
-			zap.String("handler", "UpsertMemberScoresHandler"),
+			zap.String("handler", "UpsertMembersScoreHandler"),
 		)
 		leaderboardID := c.Param("leaderboardID")
 

--- a/api/leaderboard.go
+++ b/api/leaderboard.go
@@ -54,11 +54,11 @@ func serializeMembers(members []*leaderboard.Member, includePosition bool, inclu
 	return serializedMembers
 }
 
-// UpsertMembersScoreHandler is the handler responsible for creating or updating members score
-func UpsertMembersScoreHandler(app *App) func(c echo.Context) error {
+// BulkUpsertMembersScoreHandler is the handler responsible for creating or updating members score
+func BulkUpsertMembersScoreHandler(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		lg := app.Logger.With(
-			zap.String("handler", "UpsertMembersScoreHandler"),
+			zap.String("handler", "BulkUpsertMembersScoreHandler"),
 		)
 		leaderboardID := c.Param("leaderboardID")
 

--- a/api/leaderboard_test.go
+++ b/api/leaderboard_test.go
@@ -247,12 +247,13 @@ var _ = Describe("Leaderboard Handler", func() {
 			result3, err := a.RedisClient.Client.SMembers(redisExpirationSetKey).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result3).To(ContainElement(redisLBExpirationKey))
-			result4, err := a.RedisClient.Client.ZRangeWithScores(redisLBExpirationKey, 1, 2).Result()
+			result4, err := a.RedisClient.Client.ZScore(redisLBExpirationKey, "memberpublicid1").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result4[0].Member).To(Equal("memberpublicid1"))
-			Expect(result4[0].Score).To(BeNumerically("~", time.Now().Unix()+int64(ttl), 1))
-			Expect(result4[1].Member).To(Equal("memberpublicid2"))
-			Expect(result4[1].Score).To(BeNumerically("~", time.Now().Unix()+int64(ttl), 1))
+			Expect(result4).To(BeNumerically("~", time.Now().Unix()+int64(ttl), 1))
+			result5, err := a.RedisClient.Client.ZScore(redisLBExpirationKey, "memberpublicid2").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result5).To(BeNumerically("~", time.Now().Unix()+int64(ttl), 1))
+
 		})
 
 		It("Should set correct members scores in redis and respond with previous rank", func() {
@@ -452,10 +453,9 @@ var _ = Describe("Leaderboard Handler", func() {
 			result3, err := a.RedisClient.Client.SMembers(redisExpirationSetKey).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result3).To(ContainElement(redisLBExpirationKey))
-			result4, err := a.RedisClient.Client.ZRangeWithScores(redisLBExpirationKey, 0, 1).Result()
+			result4, err := a.RedisClient.Client.ZScore(redisLBExpirationKey, "memberpublicid").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result4[0].Member).To(Equal("memberpublicid"))
-			Expect(result4[0].Score).To(BeNumerically("~", time.Now().Unix()+int64(ttl), 1))
+			Expect(result4).To(BeNumerically("~", time.Now().Unix()+int64(ttl), 1))
 		})
 
 		It("Should set correct member score in redis and respond with previous rank", func() {

--- a/api/payload.go
+++ b/api/payload.go
@@ -69,6 +69,33 @@ func (s *incrementScorePayload) Validate() []string {
 	return v.Errors()
 }
 
+type setMembersScorePayload struct {
+	MembersScore []*memberScorePayload `json:"members"`
+}
+
+type memberScorePayload struct {
+	Score int64 `json:"score"`
+	PublicID string `json:"publicID"`
+}
+
+func (s *setMembersScorePayload) Validate() []string {
+	v := NewValidation()
+
+	v.validateCustom("members", func() []string {
+		if len(s.MembersScore) == 0 {
+			return []string{"members is required"}
+		}
+		for _, memberScore := range s.MembersScore {
+			if memberScore.PublicID == "" {
+				return []string{"publicID is required"}
+			}
+		}
+		return []string{}
+	})
+
+	return v.Errors()
+}
+
 type setScorePayload struct {
 	Score int64 `json:"score"`
 }


### PR DESCRIPTION
**Description**

Created new route, which will enable podium to insert/update many members in one operation only. Making the number of requests much lower.
The feature has been covered by tests and has been tested correctly.

**How to Test**

Do a HTTP PUT in /l/:leaderboardID/scores with {"members": [{"publicID": ":publicID", "score": ":score"}]}