### PR TITLE
Fix error in API docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -519,7 +519,7 @@ Podium API
     * e.g. `GET /l/:leaderboardID/members/:memberPublicID/around?pageSize=10?order=asc`
     * defaults to "desc"
   * getLastIfNotFound=[true|false]
-    * if set to true, will treat members not in ranking as being in last position
+    * if set to true, will return the last members of the ranking when the member is not in the ranking
     * if set to false, will return 404 when the member is not in the ranking
     * e.g. `GET /l/:leaderboardID/members/:memberPublicID/around?getLastIfNotFound=true`
     * defaults to "false"


### PR DESCRIPTION
Documentation currently states that the "get members around member" route with the query parameter  "getLastIfNotFound" set to true treats members not found in the ranking as being in the last position. However, that implies that the member will be included in the returning member list, which is not the case. I have reworded this sentence to reflect better what the implementation does.