### PR TITLE
Add build and push to ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,10 +41,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15.2
       - name: Generate executable
         run: make setup cross
       - name: Login to Docker Hub
@@ -75,7 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tests
-      - performance
     steps:
       - uses: actions/checkout@v2
       - name: Set env
@@ -91,7 +86,7 @@ jobs:
         with:
           go-version: 1.15.2
       - name: Generate executable
-        run: make setup-ci cross
+        run: make setup cross
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,96 @@ jobs:
         run: make setup
       - name: Test
         run: make test
+  build_and_deploy_podium:
+    needs:
+      - tests
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.2
+      - name: Generate executable
+        run: make setup cross
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push tag
+        id: docker_build_tag
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: tfgco/podium:${{ env.VERSION }}
+      - name: Build and push latest
+        id: docker_build_latest
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: tfgco/podium:latest
+  build_and_deploy_podium_dev:
+    runs-on: ubuntu-latest
+    needs:
+      - tests
+      - performance
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.2
+      - name: Generate executable
+        run: make setup-ci cross
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Copy necessary files
+        run: cp ./config/default.yaml ./dev
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push tag
+        id: docker_build_tag
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: tfgco/podium-dev:${{ env.VERSION }}
+      - name: Build and push latest
+        id: docker_build_latest
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: tfgco/podium-dev:latest
+        

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,6 @@ cross-linux:
 
 cross-darwin:
 	@mkdir -p ./bin
-	@echo "Building for darwin-i386..."
-	@env GOOS=darwin GOARCH=386 go build -o ./bin/podium-darwin-i386 ./main.go
 	@echo "Building for darwin-x86_64..."
 	@env GOOS=darwin GOARCH=amd64 go build -o ./bin/podium-darwin-x86_64 ./main.go
 	@$(MAKE) cross-exec


### PR DESCRIPTION
WHY
=======

Podium ci only executes a test step. This PR proposes to add `build_and_push` steps that to each commit successfully tested will push a new image to [podium-dev repository](https://hub.docker.com/r/tfgco/podium-dev) and to each new tag will push a new image to [podium repository](https://hub.docker.com/r/tfgco/podium)

WHAT WAS DONE
=======
* Add build_and_push_dev step to ci
* Add build_and_push step to ci