### PR TITLE
Do not create Leaderboard docker imgs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,7 +88,7 @@ jobs:
           tags: tfgco/podium:latest
   build_and_deploy_podium_dev:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'leaderboard/')
+    if: (!(startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'leaderboard/')))
     needs:
       - tests
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
     needs:
       - tests
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'leaderboard/')
     steps:
       - uses: actions/checkout@v2
       - name: Set env

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,6 +88,7 @@ jobs:
           tags: tfgco/podium:latest
   build_and_deploy_podium_dev:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'leaderboard/')
     needs:
       - tests
     steps:


### PR DESCRIPTION
Ever since the last release #40, we now have a leaderboard module that does not have a docker image, so this PR strips it out