### PR TITLE
Create docker-compose to redis-cluster and fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ LOCAL_REDIS_PORT=6379
 LOCAL_TEST_REDIS_PORT=6379
 PROTOTOOL := go run github.com/uber/prototool/cmd/prototool
 
+.PHONY: build
+
 setup-hooks:
 	@cd .git/hooks && ln -sf ../../hooks/pre-commit.sh pre-commit
 

--- a/bench/helpers.go
+++ b/bench/helpers.go
@@ -15,15 +15,24 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/spf13/viper"
+	. "github.com/onsi/gomega"
 	"github.com/topfreegames/extensions/redis"
 	"github.com/topfreegames/podium/leaderboard"
+	"github.com/topfreegames/podium/testing"
 )
 
 func getRedis() *redis.Client {
-	config := viper.New()
-	config.Set("redis.url", "redis://localhost:6379/0")
-	config.Set("redis.connectionTimeout", 200)
+	config, err := testing.GetDefaultConfig("../config/default.yaml")
+	Expect(err).NotTo(HaveOccurred())
+
+	redisHost := config.GetString("redis.host")
+	redisPort := config.GetInt("redis.port")
+	redisDB := config.GetInt("redis.db")
+
+	redisURL := fmt.Sprintf("redis://%s:%d/%d", redisHost, redisPort, redisDB)
+
+	config.SetDefault("redis.url", redisURL)
+	config.SetDefault("redis.connectionTimeout", 200)
 
 	redisClient, err := redis.NewClient("redis", config)
 	if err != nil {

--- a/build/InitializeRedisClusterDockerfile
+++ b/build/InitializeRedisClusterDockerfile
@@ -1,0 +1,12 @@
+FROM redis:6.2.1-alpine
+
+ARG HOST_IP
+
+ENV IP $HOST_IP
+
+COPY ./build/package/initialize_cluster.sh /initialize_cluster.sh
+
+RUN apk --no-cache --update add bind-tools  bash && \
+  chmod +x /initialize_cluster.sh
+
+ENTRYPOINT ["/bin/sh", "-c", "/initialize_cluster.sh"]

--- a/build/RedisClusterDockerfile
+++ b/build/RedisClusterDockerfile
@@ -1,0 +1,8 @@
+FROM redis:6.2.1-alpine
+
+RUN apk --update --no-cache add bash
+
+COPY ./build/package/redis_cluster.conf /redis_model.conf
+COPY ./build/package/start_redis.sh /start_redis.sh
+
+ENTRYPOINT [ "/start_redis.sh" ]

--- a/build/TestAppDockerfile
+++ b/build/TestAppDockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.16.3-alpine
+
+RUN apk --no-cache --update add make g++
+
+COPY . /podium
+
+WORKDIR /podium
+
+ENTRYPOINT [ "/bin/sh", "-c", "make setup all-tests" ]

--- a/build/package/initialize_cluster.sh
+++ b/build/package/initialize_cluster.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 HOSTS=$(echo $CLUSTER_HOSTS | tr " " "\n")
-i=0
 HOST_PORTS=()
 for element in $HOSTS; do
   HOST_NAME=$(echo $element | cut -d ":" -f 1)
@@ -9,7 +8,6 @@ for element in $HOSTS; do
   IP=$(host ${HOST_NAME} | grep "has address" | cut -d " " -f 4)
 
   HOST_PORTS=("${HOST_PORTS[@]}" "$(echo $IP:$PORT)")
-  i=$(($i + 1))
 done
 
 redis-cli --cluster create ${HOST_PORTS[@]} --cluster-yes

--- a/build/package/initialize_cluster.sh
+++ b/build/package/initialize_cluster.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+HOSTS=$(echo $CLUSTER_HOSTS | tr " " "\n")
+i=0
+HOST_PORTS=()
+for element in $HOSTS; do
+  HOST_NAME=$(echo $element | cut -d ":" -f 1)
+  PORT=$(echo $element | cut -d ":" -f 2)
+  IP=$(host ${HOST_NAME} | grep "has address" | cut -d " " -f 4)
+
+  HOST_PORTS=("${HOST_PORTS[@]}" "$(echo $IP:$PORT)")
+  i=$(($i + 1))
+done
+
+redis-cli --cluster create ${HOST_PORTS[@]} --cluster-yes

--- a/build/package/redis_cluster.conf
+++ b/build/package/redis_cluster.conf
@@ -1,0 +1,5 @@
+port 6379
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly yes

--- a/build/package/start_redis.sh
+++ b/build/package/start_redis.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed "s/<<PORT>>/$PORT/g" /redis_model.conf > /redis.conf
+
+redis-server /redis.conf

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -5,6 +5,7 @@ redis:
   host: localhost
   port: 6379
   connectionTimeout: 200
+  db: 0
 
 api:
   maxReturnedMembers: 2000

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -1,0 +1,70 @@
+version: '3'
+services:
+  redis-node-0:
+    build:
+      context: ../
+      dockerfile: ./build/RedisClusterDockerfile
+    image: redis-cluster:6.2.1-alpine
+    networks:
+      podium:
+        aliases:
+          - redis-node-0
+  redis-node-1:
+    build:
+      context: ../
+      dockerfile: ./build/RedisClusterDockerfile
+    image: redis-cluster:6.2.1-alpine
+    networks:
+      podium:
+        aliases:
+          - redis-node-1
+  redis-node-2:
+    build:
+      context: ../
+      dockerfile: ./build/RedisClusterDockerfile
+    image: redis-cluster:6.2.1-alpine
+    networks:
+      podium:
+        aliases:
+          - redis-node-2
+
+  initialize-cluster:
+    build:
+      context: ../
+      dockerfile: ./build/InitializeRedisClusterDockerfile
+    image: initialize-redis-cluster:6.2.1-alpine
+    environment:
+      - "CLUSTER_HOSTS=redis-node-0:6379 redis-node-1:6379 redis-node-2:6379"
+    depends_on:
+      - redis-node-0
+      - redis-node-1
+      - redis-node-2
+    networks:
+      - podium
+
+  redis-standalone:
+    image: redis:6.2.1-alpine
+    networks:
+      podium:
+        aliases:
+          - redis-standalone
+
+  podium-test:
+    build:
+      context: ../
+      dockerfile: ./build/TestAppDockerfile
+    depends_on:
+      - redis-node-0
+      - redis-node-1
+      - redis-node-2
+      - redis-standalone
+    environment:
+      - "PODIUM_REDIS_HOST=redis-standalone"
+    volumes:
+      - "../:/podium"
+      - "/Users/arthur.nogueira/.asdf/installs/golang/1.15.2/packages/pkg/mod:/go/pkg/mod"
+    networks:
+      - podium
+
+networks:
+  podium:

--- a/leaderboard/leaderboard_test.go
+++ b/leaderboard/leaderboard_test.go
@@ -15,11 +15,11 @@ import (
 	"time"
 
 	"github.com/go-redis/redis"
-	"github.com/spf13/viper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/topfreegames/podium/leaderboard"
+	"github.com/topfreegames/podium/leaderboard/testing"
 
 	uuid "github.com/satori/go.uuid"
 	extredis "github.com/topfreegames/extensions/redis"
@@ -34,14 +34,16 @@ var _ = Describe("Leaderboard Model", func() {
 
 	BeforeEach(func() {
 		var err error
-		const host = "localhost"
-		const port = 6379
-		const db = 0
-		const connectionTimeout = 200
+		config, err := testing.GetDefaultConfig("../config/test.yaml")
+		Expect(err).NotTo(HaveOccurred())
 
-		config := viper.New()
-		config.Set("redis.url", fmt.Sprintf("redis://%s:%d/%d", host, port, db))
-		config.Set("redis.connectionTimeout", connectionTimeout)
+		host := config.GetString("redis.host")
+		port := config.GetInt("redis.port")
+		db := config.GetInt("redis.db")
+		connectionTimeout := 200
+
+		config.SetDefault("redis.url", fmt.Sprintf("redis://%s:%d/%d", host, port, db))
+		config.SetDefault("redis.connectionTimeout", connectionTimeout)
 
 		redisClient, err = extredis.NewClient("redis", config)
 		Expect(err).NotTo(HaveOccurred())

--- a/leaderboard/testing/config.go
+++ b/leaderboard/testing/config.go
@@ -1,0 +1,29 @@
+package testing
+
+import (
+	"context"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+//Creates an empty context (shortcut for context.Background())
+func NewEmptyCtx() context.Context {
+	return context.Background()
+}
+
+// GetDefaultConfig configure viper to use the config file
+func GetDefaultConfig(configFile string) (*viper.Viper, error) {
+	config := viper.New()
+	config.SetConfigFile(configFile)
+	config.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	config.SetEnvPrefix("podium")
+	config.AddConfigPath("$HOME")
+	config.AutomaticEnv()
+
+	err := config.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/testing/config.go
+++ b/testing/config.go
@@ -1,0 +1,23 @@
+package testing
+
+import (
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// GetDefaultConfig configure viper to use the config file
+func GetDefaultConfig(configFile string) (*viper.Viper, error) {
+	config := viper.New()
+	config.SetConfigFile(configFile)
+	config.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	config.SetEnvPrefix("podium")
+	config.AddConfigPath("$HOME")
+	config.AutomaticEnv()
+
+	err := config.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}


### PR DESCRIPTION
WHY
======

Currently, Podium only has the environment to test Redis standalone. This PR proposes to create a docker-compose file that will create a proper environment to test these new features.

WHAT WAS DONE
======
* Create `docker-compose.yaml`
* Fix tests