### PR TITLE
Create leaderboard/redis package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,15 @@ jobs:
         ports:
           - '6379:6379'
     steps:
+      - name: Instantiate redis cluster
+        uses: vishnudxb/redis-cluster@1.0.5
+        with:
+          master1-port: 5000
+          master2-port: 5001
+          master3-port: 5002
+          slave1-port: 5003
+          slave2-port: 5004
+          slave3-port: 5005
       - id: go-cache-paths
         run: |
           echo "::set-output name=go-build::$(go env GOCACHE)"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,6 +2,7 @@ healthcheck:
   workingText: WORKING
 
 redis:
+  addrs: "localhost:5000"
   host: localhost
   port: 6379
   password: ""

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -2,6 +2,7 @@ healthcheck:
   workingText: WORKING
 
 redis:
+  addrs: "localhost:5000"
   host: localhost
   port: 6379
   connectionTimeout: 200

--- a/deployments/docker-compose-model.yaml
+++ b/deployments/docker-compose-model.yaml
@@ -60,6 +60,7 @@ services:
       - redis-standalone
     environment:
       - "PODIUM_REDIS_HOST=redis-standalone"
+      - "PODIUM_REDIS_ADDRS=redis-node-0:6379"
     volumes:
       - "../:/podium"
       - "<<LOCAL_GO_MODCACHE>>:/go/pkg/mod"

--- a/leaderboard/go.mod
+++ b/leaderboard/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/bsm/redis-lock v6.0.0+incompatible // indirect
 	github.com/go-redis/redis v6.13.2+incompatible
+	github.com/go-redis/redis/v8 v8.8.2
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/leaderboard/go.sum
+++ b/leaderboard/go.sum
@@ -42,7 +42,10 @@ github.com/bsm/redis-lock v6.0.0+incompatible/go.mod h1:8dGkQ5GimBCahwF2R67tqGCJ
 github.com/bsm/redis-lock v8.0.0+incompatible h1:QgB0J2pNG8hUfndTIvpPh38F5XsUTTvO7x8Sls++9Mk=
 github.com/bsm/redis-lock v8.0.0+incompatible/go.mod h1:8dGkQ5GimBCahwF2R67tqGCJbyDZSp0gzO7wq3pDrik=
 github.com/certifi/gocertifi v0.0.0-20170727155124-3fd9e1adb12b/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/confluentinc/confluent-kafka-go v0.11.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -59,6 +62,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/eapache/go-resiliency v1.0.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20160609142408-bb955e01b934/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -84,6 +89,9 @@ github.com/go-pg/pg v6.15.1+incompatible/go.mod h1:a2oXow+aFOrvwcKs3eIA0lNFmMilr
 github.com/go-redis/redis v6.12.0+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redis v6.13.2+incompatible h1:kfEWSpgBs4XmuzGg7nYPqhQejjzU9eKdIL0PmE2TtRY=
 github.com/go-redis/redis v6.13.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis/v8 v8.8.2 h1:O/NcHqobw7SEptA0yA6up6spZVFtwE06SXM8rgLtsP8=
+github.com/go-redis/redis/v8 v8.8.2/go.mod h1:F7resOH5Kdug49Otu24RjHWwgK7u9AmtqWMnCV1iP5Y=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
@@ -116,6 +124,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -218,10 +227,12 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
 github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.11.0 h1:+CqWgvj0OZycCaqclBD1pxKHAU+tOkHmQIWvDHq2aug=
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
@@ -287,6 +298,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -311,6 +323,13 @@ github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wK
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opentelemetry.io/otel v0.19.0 h1:Lenfy7QHRXPZVsw/12CWpxX6d/JkrX8wrx2vO8G80Ng=
+go.opentelemetry.io/otel v0.19.0/go.mod h1:j9bF567N9EfomkSidSfmMwIwIBuP37AMAIzVW85OxSg=
+go.opentelemetry.io/otel/metric v0.19.0 h1:dtZ1Ju44gkJkYvo+3qGqVXmf88tc+a42edOywypengg=
+go.opentelemetry.io/otel/metric v0.19.0/go.mod h1:8f9fglJPRnXuskQmKpnad31lcLJ2VmNNqIsx/uIwBSc=
+go.opentelemetry.io/otel/oteltest v0.19.0/go.mod h1:tI4yxwh8U21v7JD6R3BcA/2+RBoTKFexE/PJ/nSO7IA=
+go.opentelemetry.io/otel/trace v0.19.0 h1:1ucYlenXIDA1OlHVLDZKX0ObXV5RLaq06DtUKz5e5zc=
+go.opentelemetry.io/otel/trace v0.19.0/go.mod h1:4IXiNextNOpPnRlI4ryK69mn5iC84bjBWZQA5DXz/qg=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/leaderboard/redis/cluster_client.go
+++ b/leaderboard/redis/cluster_client.go
@@ -32,7 +32,7 @@ func NewClusterClient(clusterOptions ClusterOptions) Redis {
 func (cc *clusterClient) ExpireAt(ctx context.Context, key string, time time.Time) error {
 	result, err := cc.ClusterClient.ExpireAt(ctx, key, time).Result()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 
 	if result != true {
@@ -46,7 +46,7 @@ func (cc *clusterClient) ExpireAt(ctx context.Context, key string, time time.Tim
 func (cc *clusterClient) Ping(ctx context.Context) error {
 	err := cc.ClusterClient.Ping(ctx).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -55,7 +55,7 @@ func (cc *clusterClient) Ping(ctx context.Context) error {
 func (cc *clusterClient) SAdd(ctx context.Context, key, member string) error {
 	err := cc.ClusterClient.SAdd(ctx, key, member).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -64,7 +64,7 @@ func (cc *clusterClient) SAdd(ctx context.Context, key, member string) error {
 func (cc *clusterClient) SRem(ctx context.Context, key, member string) error {
 	err := cc.ClusterClient.SRem(ctx, key, member).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -73,7 +73,7 @@ func (cc *clusterClient) SRem(ctx context.Context, key, member string) error {
 func (cc *clusterClient) TTL(ctx context.Context, key string) (time.Duration, error) {
 	result, err := cc.ClusterClient.TTL(ctx, key).Result()
 	if err != nil {
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	if result == TTLKeyNotFound {
@@ -91,7 +91,7 @@ func (cc *clusterClient) TTL(ctx context.Context, key string) (time.Duration, er
 func (cc *clusterClient) ZAdd(ctx context.Context, key, member string, score float64) error {
 	err := cc.ClusterClient.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -100,7 +100,7 @@ func (cc *clusterClient) ZAdd(ctx context.Context, key, member string, score flo
 func (cc *clusterClient) ZCard(ctx context.Context, key string) (int64, error) {
 	result, err := cc.ClusterClient.ZCard(ctx, key).Result()
 	if err != nil {
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	if result == 0 {
@@ -114,7 +114,7 @@ func (cc *clusterClient) ZCard(ctx context.Context, key string) (int64, error) {
 func (cc *clusterClient) ZIncrBy(ctx context.Context, key, member string, increment float64) error {
 	_, err := cc.ClusterClient.ZIncrBy(ctx, key, increment, member).Result()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -123,7 +123,7 @@ func (cc *clusterClient) ZIncrBy(ctx context.Context, key, member string, increm
 func (cc *clusterClient) ZRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
 	result, err := cc.ClusterClient.ZRangeWithScores(ctx, key, start, stop).Result()
 	if err != nil {
-		return nil, NewUnknowError(err.Error())
+		return nil, NewUnknownError(err.Error())
 	}
 
 	var members []*Member = make([]*Member, 0, len(result))
@@ -145,7 +145,7 @@ func (cc *clusterClient) ZRank(ctx context.Context, key, member string) (int64, 
 			return -1, NewMemberNotFoundError(key)
 		}
 
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	return result, nil
@@ -155,7 +155,7 @@ func (cc *clusterClient) ZRank(ctx context.Context, key, member string) (int64, 
 func (cc *clusterClient) ZRem(ctx context.Context, key, member string) error {
 	err := cc.ClusterClient.ZRem(ctx, key, member).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -164,7 +164,7 @@ func (cc *clusterClient) ZRem(ctx context.Context, key, member string) error {
 func (cc *clusterClient) ZRevRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
 	result, err := cc.ClusterClient.ZRevRangeWithScores(ctx, key, start, stop).Result()
 	if err != nil {
-		return nil, NewUnknowError(err.Error())
+		return nil, NewUnknownError(err.Error())
 	}
 
 	var members []*Member = make([]*Member, 0, len(result))
@@ -186,7 +186,7 @@ func (cc *clusterClient) ZRevRank(ctx context.Context, key, member string) (int6
 			return -1, NewMemberNotFoundError(key)
 		}
 
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	return result, nil
@@ -200,7 +200,7 @@ func (cc *clusterClient) ZScore(ctx context.Context, key, member string) (float6
 			return -1, NewMemberNotFoundError(key)
 		}
 
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	return result, nil

--- a/leaderboard/redis/cluster_client.go
+++ b/leaderboard/redis/cluster_client.go
@@ -44,28 +44,19 @@ func (cc *clusterClient) ExpireAt(ctx context.Context, key string, time time.Tim
 // Ping call redis PING function
 func (cc *clusterClient) Ping(ctx context.Context) error {
 	err := cc.ClusterClient.Ping(ctx).Err()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // SAdd call redis SADD function
 func (cc *clusterClient) SAdd(ctx context.Context, key, member string) error {
 	_, err := cc.ClusterClient.SAdd(ctx, key, member).Result()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // SRem call redis SREM function
 func (cc *clusterClient) SRem(ctx context.Context, key, member string) error {
 	err := cc.ClusterClient.SRem(ctx, key, member).Err()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // TTL call redis TTL function
@@ -89,11 +80,7 @@ func (cc *clusterClient) TTL(ctx context.Context, key string) (time.Duration, er
 // ZAdd call redis ZADD function
 func (cc *clusterClient) ZAdd(ctx context.Context, key, member string, score float64) error {
 	_, err := cc.ClusterClient.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Result()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ZCard call redis ZCARD function
@@ -113,11 +100,7 @@ func (cc *clusterClient) ZCard(ctx context.Context, key string) (int64, error) {
 // ZIncrBy call redis ZINCRBY function
 func (cc *clusterClient) ZIncrBy(ctx context.Context, key, member string, increment float64) error {
 	_, err := cc.ClusterClient.ZIncrBy(ctx, key, increment, member).Result()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ZRange call redis ZRANGE function it is inclusive it returns start and stop element
@@ -155,10 +138,7 @@ func (cc *clusterClient) ZRank(ctx context.Context, key, member string) (int64, 
 // ZRem call redis ZREM function
 func (cc *clusterClient) ZRem(ctx context.Context, key, member string) error {
 	err := cc.ClusterClient.ZRem(ctx, key, member).Err()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // ZRevRange call redis ZREVRANGE function it is inclusive it returns start and stop element

--- a/leaderboard/redis/cluster_client.go
+++ b/leaderboard/redis/cluster_client.go
@@ -43,12 +43,12 @@ func (cc *clusterClient) ExpireAt(ctx context.Context, key string, time time.Tim
 }
 
 // Ping call redis PING function
-func (cc *clusterClient) Ping(ctx context.Context) error {
-	err := cc.ClusterClient.Ping(ctx).Err()
+func (cc *clusterClient) Ping(ctx context.Context) (string, error) {
+	result, err := cc.ClusterClient.Ping(ctx).Result()
 	if err != nil {
-		return NewUnknownError(err.Error())
+		return "", NewUnknownError(err.Error())
 	}
-	return nil
+	return result, nil
 }
 
 // SAdd call redis SADD function

--- a/leaderboard/redis/cluster_client.go
+++ b/leaderboard/redis/cluster_client.go
@@ -13,14 +13,14 @@ type clusterClient struct {
 }
 
 type ClusterOptions struct {
-	Hosts    []string
+	Addrs    []string
 	Password string
 }
 
 // NewClusterClient returns a new redis instance
 func NewClusterClient(clusterOptions ClusterOptions) *clusterClient {
 	goRedisClient := goredis.NewClusterClient(&goredis.ClusterOptions{
-		Addrs:    clusterOptions.Hosts,
+		Addrs:    clusterOptions.Addrs,
 		Password: clusterOptions.Password,
 	})
 
@@ -66,11 +66,11 @@ func (cc *clusterClient) TTL(ctx context.Context, key string) (time.Duration, er
 		return -1, err
 	}
 
-	if result == -2 {
+	if result == TTLKeyNotFound {
 		return -1, NewKeyNotFoundError(key)
 	}
 
-	if result == -1 {
+	if result == TTLNotFoundToKey {
 		return -1, NewTTLNotFoundError(key)
 	}
 

--- a/leaderboard/redis/cluster_client.go
+++ b/leaderboard/redis/cluster_client.go
@@ -1,0 +1,208 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	goredis "github.com/go-redis/redis/v8"
+)
+
+type clusterClient struct {
+	*goredis.ClusterClient
+}
+
+type ClusterOptions struct {
+	Hosts    []string
+	Password string
+}
+
+// NewClusterClient returns a new redis instance
+func NewClusterClient(clusterOptions ClusterOptions) *clusterClient {
+	goRedisClient := goredis.NewClusterClient(&goredis.ClusterOptions{
+		Addrs:    clusterOptions.Hosts,
+		Password: clusterOptions.Password,
+	})
+
+	return &clusterClient{goRedisClient}
+}
+
+// ExpireAt call redis EXPIREAT function
+func (cc *clusterClient) ExpireAt(ctx context.Context, key string, time time.Time) error {
+	result, err := cc.ClusterClient.ExpireAt(ctx, key, time).Result()
+	if err != nil {
+		return err
+	}
+
+	if result != true {
+		return NewKeyNotFoundError(key)
+	}
+
+	return nil
+}
+
+// Ping call redis PING function
+func (cc *clusterClient) Ping(ctx context.Context) error {
+	err := cc.ClusterClient.Ping(ctx).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SAdd call redis SADD function
+func (cc *clusterClient) SAdd(ctx context.Context, key, member string) error {
+	_, err := cc.ClusterClient.SAdd(ctx, key, member).Result()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SRem call redis SREM function
+func (cc *clusterClient) SRem(ctx context.Context, key, member string) error {
+	err := cc.ClusterClient.SRem(ctx, key, member).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// TTL call redis TTL function
+func (cc *clusterClient) TTL(ctx context.Context, key string) (time.Duration, error) {
+	result, err := cc.ClusterClient.TTL(ctx, key).Result()
+	if err != nil {
+		return -1, err
+	}
+
+	if result == -2 {
+		return -1, NewKeyNotFoundError(key)
+	}
+
+	if result == -1 {
+		return -1, NewTTLNotFoundError(key)
+	}
+
+	return result, nil
+}
+
+// ZAdd call redis ZADD function
+func (cc *clusterClient) ZAdd(ctx context.Context, key, member string, score float64) error {
+	_, err := cc.ClusterClient.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Result()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ZCard call redis ZCARD function
+func (cc *clusterClient) ZCard(ctx context.Context, key string) (int64, error) {
+	result, err := cc.ClusterClient.ZCard(ctx, key).Result()
+	if err != nil {
+		return -1, err
+	}
+
+	if result == 0 {
+		return -1, NewKeyNotFoundError(key)
+	}
+
+	return result, nil
+}
+
+// ZIncrBy call redis ZINCRBY function
+func (cc *clusterClient) ZIncrBy(ctx context.Context, key, member string, increment float64) error {
+	_, err := cc.ClusterClient.ZIncrBy(ctx, key, increment, member).Result()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ZRange call redis ZRANGE function it is inclusive it returns start and stop element
+func (cc *clusterClient) ZRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
+	result, err := cc.ClusterClient.ZRangeWithScores(ctx, key, start, stop).Result()
+	if err != nil {
+		return []*Member{}, err
+	}
+
+	var members []*Member = make([]*Member, 0, len(result))
+	for _, member := range result {
+		members = append(members, &Member{
+			Member: fmt.Sprint(member.Member),
+			Score:  member.Score,
+		})
+	}
+
+	return members, nil
+}
+
+// ZRank call redis ZRANK function
+func (cc *clusterClient) ZRank(ctx context.Context, key, member string) (int64, error) {
+	result, err := cc.ClusterClient.ZRank(ctx, key, member).Result()
+	if err != nil {
+		if err.Error() == "redis: nil" {
+			return 0, NewMemberNotFoundError(key)
+		}
+
+		return 0, err
+	}
+
+	return result, nil
+}
+
+// ZRem call redis ZREM function
+func (cc *clusterClient) ZRem(ctx context.Context, key, member string) error {
+	err := cc.ClusterClient.ZRem(ctx, key, member).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ZRevRange call redis ZREVRANGE function it is inclusive it returns start and stop element
+func (cc *clusterClient) ZRevRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
+	result, err := cc.ClusterClient.ZRevRangeWithScores(ctx, key, start, stop).Result()
+	if err != nil {
+		return []*Member{}, err
+	}
+
+	var members []*Member = make([]*Member, 0, len(result))
+	for _, member := range result {
+		members = append(members, &Member{
+			Member: fmt.Sprint(member.Member),
+			Score:  member.Score,
+		})
+	}
+
+	return members, nil
+}
+
+// ZRevRank call redis ZRevRank function
+func (cc *clusterClient) ZRevRank(ctx context.Context, key, member string) (int64, error) {
+	result, err := cc.ClusterClient.ZRevRank(ctx, key, member).Result()
+	if err != nil {
+		if err.Error() == "redis: nil" {
+			return 0, NewMemberNotFoundError(key)
+		}
+
+		return 0, err
+	}
+
+	return result, nil
+}
+
+// ZScore call redis ZScore function
+func (cc *clusterClient) ZScore(ctx context.Context, key, member string) (float64, error) {
+	result, err := cc.ClusterClient.ZScore(ctx, key, member).Result()
+	if err != nil {
+		if err.Error() == "redis: nil" {
+			return 0, NewMemberNotFoundError(key)
+		}
+
+		return 0, err
+	}
+
+	return result, nil
+}

--- a/leaderboard/redis/cluster_client.go
+++ b/leaderboard/redis/cluster_client.go
@@ -80,7 +80,7 @@ func (cc *clusterClient) TTL(ctx context.Context, key string) (time.Duration, er
 		return -1, NewKeyNotFoundError(key)
 	}
 
-	if result == TTLNotFoundToKey {
+	if result == KeyWithoutTTL {
 		return -1, NewTTLNotFoundError(key)
 	}
 

--- a/leaderboard/redis/cluster_client_test.go
+++ b/leaderboard/redis/cluster_client_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Leaderboard Model", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		clusterClient = redis.NewClusterClient(redis.ClusterOptions{
-			Hosts:    config.GetStringSlice("redis.addrs"),
+			Addrs:    config.GetStringSlice("redis.addrs"),
 			Password: config.GetString("redis.password"),
 		})
 
@@ -53,8 +53,8 @@ var _ = Describe("Leaderboard Model", func() {
 			ttl, err := goRedis.TTL(context.Background(), testKey).Result()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
-			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+			Expect(ttl).NotTo(Equal(redis.TTLKeyNotFound))
+			Expect(ttl).NotTo(Equal(redis.TTLNotFoundToKey))
 
 			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
 		})

--- a/leaderboard/redis/cluster_client_test.go
+++ b/leaderboard/redis/cluster_client_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Cluster Client", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(ttl).NotTo(Equal(redis.TTLKeyNotFound))
-			Expect(ttl).NotTo(Equal(redis.TTLNotFoundToKey))
+			Expect(ttl).NotTo(Equal(redis.KeyWithoutTTL))
 
 			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
 		})
@@ -114,8 +114,8 @@ var _ = Describe("Cluster Client", func() {
 			ttl, err := clusterClient.TTL(context.Background(), testKey)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
-			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+			Expect(ttl).NotTo(Equal(redis.TTLKeyNotFound))
+			Expect(ttl).NotTo(Equal(redis.KeyWithoutTTL))
 
 			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
 		})

--- a/leaderboard/redis/cluster_client_test.go
+++ b/leaderboard/redis/cluster_client_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Leaderboard Model", func() {
+var _ = Describe("Cluster Client", func() {
 	const testKey string = "testKey"
 	const member string = "member"
 

--- a/leaderboard/redis/cluster_client_test.go
+++ b/leaderboard/redis/cluster_client_test.go
@@ -1,0 +1,330 @@
+package redis_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	goredis "github.com/go-redis/redis/v8"
+	"github.com/topfreegames/podium/leaderboard/redis"
+	"github.com/topfreegames/podium/leaderboard/testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Leaderboard Model", func() {
+	const testKey string = "testKey"
+	const member string = "member"
+
+	var clusterClient redis.Redis
+	var goRedis *goredis.ClusterClient
+
+	BeforeEach(func() {
+		config, err := testing.GetDefaultConfig("../../config/test.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		clusterClient = redis.NewClusterClient(redis.ClusterOptions{
+			Hosts:    config.GetStringSlice("redis.addrs"),
+			Password: config.GetString("redis.password"),
+		})
+
+		goRedis = goredis.NewClusterClient(&goredis.ClusterOptions{
+			Addrs:    config.GetStringSlice("redis.addrs"),
+			Password: config.GetString("redis.password"),
+		})
+	})
+
+	AfterEach(func() {
+		err := goRedis.Del(context.Background(), testKey).Err()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("ExpireAt", func() {
+		It("Should return nil if timeout is set", func() {
+			expirationTime := time.Now().Add(10 * time.Minute)
+
+			err := goRedis.Set(context.Background(), testKey, "testValue", 0).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = clusterClient.ExpireAt(context.Background(), testKey, expirationTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			ttl, err := goRedis.TTL(context.Background(), testKey).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
+			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+
+			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
+		})
+
+		It("Should return KeyNotFound if key doesn't exists", func() {
+			expirationTime := time.Now().Add(10 * time.Minute)
+
+			err := clusterClient.ExpireAt(context.Background(), testKey, expirationTime)
+			Expect(err).To(Equal(redis.NewKeyNotFoundError(testKey)))
+		})
+	})
+
+	Describe("Ping", func() {
+		It("Should return nil if redis is OK", func() {
+			err := clusterClient.Ping(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("SAdd", func() {
+		It("Should return nil if member is add to set", func() {
+			err := clusterClient.SAdd(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			isMember, err := goRedis.SIsMember(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(isMember).To(Equal(true))
+		})
+	})
+
+	Describe("SRem", func() {
+		It("Should return nil if member is removed from set", func() {
+			err := goRedis.SAdd(context.Background(), testKey, member).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = clusterClient.SRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			isMember, err := goRedis.SIsMember(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(isMember).To(Equal(false))
+		})
+
+		It("Should return nil if set doesnt exists", func() {
+			err := clusterClient.SRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("TTL", func() {
+		It("Should return time.Duration if key has TTL set", func() {
+			err := goRedis.Set(context.Background(), testKey, "testValue", 10*time.Minute).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			ttl, err := clusterClient.TTL(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
+			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+
+			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
+		})
+
+		It("Should return KeyNotFound if key doesn't exists", func() {
+			_, err := clusterClient.TTL(context.Background(), testKey)
+			Expect(err).To(Equal(redis.NewKeyNotFoundError(testKey)))
+		})
+
+		It("Should return TTLNotFound if ttl was not set", func() {
+			err := goRedis.Set(context.Background(), testKey, "testValue", 0).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = clusterClient.TTL(context.Background(), testKey)
+			Expect(err).To(Equal(redis.NewTTLNotFoundError(testKey)))
+		})
+	})
+
+	Describe("ZAdd", func() {
+		It("Should return nil if member is add to set", func() {
+			score := 1.0
+			err := clusterClient.ZAdd(context.Background(), testKey, member, score)
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedScore, err := goRedis.ZScore(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedScore).To(Equal(score))
+		})
+	})
+
+	Describe("ZCard", func() {
+		It("Should return nil if member is add to set", func() {
+			member2 := "member2"
+
+			score := 1.0
+			score2 := 2.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}, &goredis.Z{Member: member2, Score: score2}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			count, err := clusterClient.ZCard(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(count).To(BeEquivalentTo(2))
+		})
+	})
+
+	Describe("ZIncrBy", func() {
+		It("Should return nil if member is updated", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = clusterClient.ZIncrBy(context.Background(), testKey, member, score)
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedScore, err := goRedis.ZScore(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedScore).To(Equal(score + score))
+		})
+	})
+
+	Describe("ZRange", func() {
+		It("Should return members ordered by score, with respective scores", func() {
+			member2 := "member2"
+
+			score := 1.0
+			score2 := 2.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}, &goredis.Z{Member: member2, Score: score2}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			members, err := clusterClient.ZRange(context.Background(), testKey, 0, -1)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(members[0].Member).To(Equal(member))
+			Expect(members[0].Score).To(Equal(score))
+
+			Expect(members[1].Member).To(Equal(member2))
+			Expect(members[1].Score).To(Equal(score2))
+		})
+	})
+
+	Describe("ZRank", func() {
+		It("Should return member rank and nil if no error ocurr", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			rank, err := clusterClient.ZRank(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rank).To(BeEquivalentTo(0))
+		})
+
+		It("Should return error MemberNotFounderror if sorted set is empty", func() {
+			_, err := clusterClient.ZRank(context.Background(), testKey, member)
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+
+		It("Should return error MemberNotFounderror if sorted set doesn't have member", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = clusterClient.ZRank(context.Background(), testKey, "member not found")
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+	})
+
+	Describe("ZRem", func() {
+		It("Should return nil if member is removed from set", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = clusterClient.ZRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = goRedis.ZRank(context.Background(), testKey, member).Result()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should return nil if set doesn't exists", func() {
+			err := clusterClient.ZRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("ZRevRange", func() {
+		It("Should return members ordered by score, with respective scores", func() {
+			member2 := "member2"
+
+			score := 1.0
+			score2 := 2.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}, &goredis.Z{Member: member2, Score: score2}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			members, err := clusterClient.ZRevRange(context.Background(), testKey, 0, -1)
+			Expect(err).NotTo(HaveOccurred())
+
+			fmt.Printf("\n\n\n%+v\n\n", members)
+
+			Expect(members[0].Member).To(Equal(member2))
+			Expect(members[0].Score).To(Equal(score2))
+
+			Expect(members[1].Member).To(Equal(member))
+			Expect(members[1].Score).To(Equal(score))
+		})
+	})
+
+	Describe("ZRevRank", func() {
+		It("Should return rank position if member is in set", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: "another-member", Score: score * 2.0}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedRank, err := clusterClient.ZRevRank(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedRank).To(BeEquivalentTo(1))
+		})
+
+		It("Should return MemberNotFound if key doesn't have member", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: "another-member", Score: score * 2.0}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = clusterClient.ZRevRank(context.Background(), testKey, "wrongKey")
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+	})
+
+	Describe("ZScore", func() {
+		It("Should return score if member is in set", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedScore, err := clusterClient.ZScore(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedScore).To(Equal(score))
+		})
+
+		It("Should return MemberNotFound if key doesn't have member", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = clusterClient.ZScore(context.Background(), testKey, "wrongKey")
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+	})
+})

--- a/leaderboard/redis/cluster_client_test.go
+++ b/leaderboard/redis/cluster_client_test.go
@@ -69,8 +69,10 @@ var _ = Describe("Cluster Client", func() {
 
 	Describe("Ping", func() {
 		It("Should return nil if redis is OK", func() {
-			err := clusterClient.Ping(context.Background())
+			result, err := clusterClient.Ping(context.Background())
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal("PONG"))
 		})
 	})
 

--- a/leaderboard/redis/errors.go
+++ b/leaderboard/redis/errors.go
@@ -1,0 +1,51 @@
+package redis
+
+import "fmt"
+
+// KeyNotFoundError is an error throw when key is not in redis
+type KeyNotFoundError struct {
+	key string
+}
+
+// NewKeyNotFoundError create a new KeyNotFoundError
+func NewKeyNotFoundError(key string) *KeyNotFoundError {
+	return &KeyNotFoundError{
+		key: key,
+	}
+}
+
+func (knfe *KeyNotFoundError) Error() string {
+	return fmt.Sprintf("redis key %s not found", knfe.key)
+}
+
+// TTLNotFoundError is an error throw when key has not TTL
+type TTLNotFoundError struct {
+	key string
+}
+
+// NewTTLNotFoundError create a new KeyNotFoundError
+func NewTTLNotFoundError(key string) *TTLNotFoundError {
+	return &TTLNotFoundError{
+		key: key,
+	}
+}
+
+func (knfe *TTLNotFoundError) Error() string {
+	return fmt.Sprintf("redis key %s not found", knfe.key)
+}
+
+// MemberNotFoundError is an error throw when key has not Member
+type MemberNotFoundError struct {
+	key string
+}
+
+// NewMemberNotFoundError create a new KeyNotFoundError
+func NewMemberNotFoundError(key string) *MemberNotFoundError {
+	return &MemberNotFoundError{
+		key: key,
+	}
+}
+
+func (mnfe *MemberNotFoundError) Error() string {
+	return fmt.Sprintf("redis key %s not found", mnfe.key)
+}

--- a/leaderboard/redis/errors.go
+++ b/leaderboard/redis/errors.go
@@ -49,3 +49,17 @@ func NewMemberNotFoundError(key string) *MemberNotFoundError {
 func (mnfe *MemberNotFoundError) Error() string {
 	return fmt.Sprintf("redis key %s not found", mnfe.key)
 }
+
+// UnknownError create a redis error that is not handled
+type UnknownError struct {
+	msg string
+}
+
+func (ue *UnknownError) Error() string {
+	return fmt.Sprintf("redis unknow error: %s", ue.msg)
+}
+
+// NewUnknownError create a new redis error that isnt handled
+func NewUnknownError(msg string) *UnknownError {
+	return &UnknownError{msg: msg}
+}

--- a/leaderboard/redis/redis.go
+++ b/leaderboard/redis/redis.go
@@ -8,8 +8,8 @@ import (
 const (
 	// TTLKeyNotFound is redis return status to TTL command that simbolize a key not found
 	TTLKeyNotFound = -2
-	// TTLNotFoundToKey is redis return status to TTL command that simbolize a key without TTL set
-	TTLNotFoundToKey = -1
+	// KeyWithoutTTL is redis return status to TTL command that simbolize a key without TTL set
+	KeyWithoutTTL = -1
 )
 
 // Redis interface define wich redis methods will be used by leaderboard module

--- a/leaderboard/redis/redis.go
+++ b/leaderboard/redis/redis.go
@@ -1,0 +1,30 @@
+package redis
+
+import (
+	"context"
+	"time"
+)
+
+// Redis interface define wich redis methods will be used by leaderboard module
+type Redis interface {
+	ExpireAt(ctx context.Context, key string, time time.Time) error
+	Ping(ctx context.Context) error
+	SAdd(ctx context.Context, key, member string) error
+	SRem(ctx context.Context, key, member string) error
+	TTL(ctx context.Context, key string) (time.Duration, error)
+	ZAdd(ctx context.Context, key, member string, score float64) error
+	ZCard(ctx context.Context, key string) (int64, error)
+	ZIncrBy(ctx context.Context, key, member string, increment float64) error
+	ZRange(ctx context.Context, key string, start, stop int64) ([]*Member, error)
+	ZRank(ctx context.Context, key, member string) (int64, error)
+	ZRem(ctx context.Context, key string, member string) error
+	ZRevRange(ctx context.Context, key string, start, stop int64) ([]*Member, error)
+	ZRevRank(ctx context.Context, key, member string) (int64, error)
+	ZScore(ctx context.Context, key, member string) (float64, error)
+}
+
+// Member is a struct to be used by sorted set range operations
+type Member struct {
+	Member string
+	Score  float64
+}

--- a/leaderboard/redis/redis.go
+++ b/leaderboard/redis/redis.go
@@ -15,7 +15,7 @@ const (
 // Redis interface define wich redis methods will be used by leaderboard module
 type Redis interface {
 	ExpireAt(ctx context.Context, key string, time time.Time) error
-	Ping(ctx context.Context) error
+	Ping(ctx context.Context) (string, error)
 	SAdd(ctx context.Context, key, member string) error
 	SRem(ctx context.Context, key, member string) error
 	TTL(ctx context.Context, key string) (time.Duration, error)

--- a/leaderboard/redis/redis.go
+++ b/leaderboard/redis/redis.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+const (
+	// TTLKeyNotFound is redis return status to TTL command that simbolize a key not found
+	TTLKeyNotFound = -2
+	// TTLNotFoundToKey is redis return status to TTL command that simbolize a key without TTL set
+	TTLNotFoundToKey = -1
+)
+
 // Redis interface define wich redis methods will be used by leaderboard module
 type Redis interface {
 	ExpireAt(ctx context.Context, key string, time time.Time) error

--- a/leaderboard/redis/redis_suite_test.go
+++ b/leaderboard/redis/redis_suite_test.go
@@ -1,0 +1,22 @@
+// podium
+// https://github.com/topfreegames/podium
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2016 Top Free Games <backend@tfgco.com>
+// Forked from
+// https://github.com/dayvson/go-leaderboard
+// Copyright © 2013 Maxwell Dayvson da Silva
+
+package redis_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLeaderboard(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Redis Suite")
+}

--- a/leaderboard/redis/standalone_client.go
+++ b/leaderboard/redis/standalone_client.go
@@ -45,12 +45,12 @@ func (c *standaloneClient) ExpireAt(ctx context.Context, key string, time time.T
 }
 
 // Ping call redis PING function
-func (c *standaloneClient) Ping(ctx context.Context) error {
-	err := c.Client.Ping(ctx).Err()
+func (c *standaloneClient) Ping(ctx context.Context) (string, error) {
+	result, err := c.Client.Ping(ctx).Result()
 	if err != nil {
-		return NewUnknownError(err.Error())
+		return "", NewUnknownError(err.Error())
 	}
-	return nil
+	return result, nil
 }
 
 // SAdd call redis SADD function

--- a/leaderboard/redis/standalone_client.go
+++ b/leaderboard/redis/standalone_client.go
@@ -71,11 +71,11 @@ func (c *standaloneClient) TTL(ctx context.Context, key string) (time.Duration, 
 		return -1, err
 	}
 
-	if result == -2 {
+	if result == TTLKeyNotFound {
 		return -1, NewKeyNotFoundError(key)
 	}
 
-	if result == -1 {
+	if result == TTLNotFoundToKey {
 		return -1, NewTTLNotFoundError(key)
 	}
 

--- a/leaderboard/redis/standalone_client.go
+++ b/leaderboard/redis/standalone_client.go
@@ -35,7 +35,7 @@ func NewStandaloneClient(options StandaloneOptions) Redis {
 func (c *standaloneClient) ExpireAt(ctx context.Context, key string, time time.Time) error {
 	result, err := c.Client.ExpireAt(ctx, key, time).Result()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 
 	if result != true {
@@ -48,7 +48,7 @@ func (c *standaloneClient) ExpireAt(ctx context.Context, key string, time time.T
 func (c *standaloneClient) Ping(ctx context.Context) error {
 	err := c.Client.Ping(ctx).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -57,7 +57,7 @@ func (c *standaloneClient) Ping(ctx context.Context) error {
 func (c *standaloneClient) SAdd(ctx context.Context, key, member string) error {
 	err := c.Client.SAdd(ctx, key, member).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -66,7 +66,7 @@ func (c *standaloneClient) SAdd(ctx context.Context, key, member string) error {
 func (c *standaloneClient) SRem(ctx context.Context, key, member string) error {
 	err := c.Client.SRem(ctx, key, member).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -75,7 +75,7 @@ func (c *standaloneClient) SRem(ctx context.Context, key, member string) error {
 func (c *standaloneClient) TTL(ctx context.Context, key string) (time.Duration, error) {
 	result, err := c.Client.TTL(ctx, key).Result()
 	if err != nil {
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	if result == TTLKeyNotFound {
@@ -93,7 +93,7 @@ func (c *standaloneClient) TTL(ctx context.Context, key string) (time.Duration, 
 func (c *standaloneClient) ZAdd(ctx context.Context, key, member string, score float64) error {
 	err := c.Client.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -102,7 +102,7 @@ func (c *standaloneClient) ZAdd(ctx context.Context, key, member string, score f
 func (c *standaloneClient) ZCard(ctx context.Context, key string) (int64, error) {
 	result, err := c.Client.ZCard(ctx, key).Result()
 	if err != nil {
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	if result == 0 {
@@ -116,7 +116,7 @@ func (c *standaloneClient) ZCard(ctx context.Context, key string) (int64, error)
 func (c *standaloneClient) ZIncrBy(ctx context.Context, key, member string, increment float64) error {
 	err := c.Client.ZIncrBy(ctx, key, increment, member).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -125,7 +125,7 @@ func (c *standaloneClient) ZIncrBy(ctx context.Context, key, member string, incr
 func (c *standaloneClient) ZRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
 	result, err := c.Client.ZRangeWithScores(ctx, key, start, stop).Result()
 	if err != nil {
-		return nil, NewUnknowError(err.Error())
+		return nil, NewUnknownError(err.Error())
 	}
 
 	var members []*Member = make([]*Member, 0, len(result))
@@ -147,7 +147,7 @@ func (c *standaloneClient) ZRank(ctx context.Context, key, member string) (int64
 			return -1, NewMemberNotFoundError(key)
 		}
 
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	return result, nil
@@ -157,7 +157,7 @@ func (c *standaloneClient) ZRank(ctx context.Context, key, member string) (int64
 func (c *standaloneClient) ZRem(ctx context.Context, key, member string) error {
 	err := c.Client.ZRem(ctx, key, member).Err()
 	if err != nil {
-		return NewUnknowError(err.Error())
+		return NewUnknownError(err.Error())
 	}
 	return nil
 }
@@ -166,7 +166,7 @@ func (c *standaloneClient) ZRem(ctx context.Context, key, member string) error {
 func (c *standaloneClient) ZRevRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
 	result, err := c.Client.ZRevRangeWithScores(ctx, key, start, stop).Result()
 	if err != nil {
-		return nil, NewUnknowError(err.Error())
+		return nil, NewUnknownError(err.Error())
 	}
 
 	var members []*Member = make([]*Member, 0, len(result))
@@ -188,7 +188,7 @@ func (c *standaloneClient) ZRevRank(ctx context.Context, key, member string) (in
 			return 0, NewMemberNotFoundError(key)
 		}
 
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	return result, nil
@@ -202,7 +202,7 @@ func (c *standaloneClient) ZScore(ctx context.Context, key, member string) (floa
 			return 0, NewMemberNotFoundError(key)
 		}
 
-		return -1, NewUnknowError(err.Error())
+		return -1, NewUnknownError(err.Error())
 	}
 
 	return result, nil

--- a/leaderboard/redis/standalone_client.go
+++ b/leaderboard/redis/standalone_client.go
@@ -1,0 +1,210 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	goredis "github.com/go-redis/redis/v8"
+)
+
+type standaloneClient struct {
+	*goredis.Client
+}
+
+type StandaloneOptions struct {
+	Host     string
+	Port     int
+	Password string
+	DB       int
+}
+
+// NewStandaloneClient returns a new redis instance
+func NewStandaloneClient(options StandaloneOptions) *standaloneClient {
+	goRedisClient := goredis.NewClient(&goredis.Options{
+		Addr:     fmt.Sprintf("%s:%d", options.Host, options.Port),
+		Password: options.Password,
+		DB:       options.DB,
+	})
+
+	return &standaloneClient{goRedisClient}
+}
+
+// ExpireAt call redis EXPIREAT function
+func (c *standaloneClient) ExpireAt(ctx context.Context, key string, time time.Time) error {
+	result, err := c.Client.ExpireAt(ctx, key, time).Result()
+	if err != nil {
+		return err
+	}
+
+	if result != true {
+		return NewKeyNotFoundError(key)
+	}
+	return nil
+}
+
+// Ping call redis PING function
+func (c *standaloneClient) Ping(ctx context.Context) error {
+	err := c.Client.Ping(ctx).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SAdd call redis SADD function
+func (c *standaloneClient) SAdd(ctx context.Context, key, member string) error {
+	err := c.Client.SAdd(ctx, key, member).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SRem call redis SREM function
+func (c *standaloneClient) SRem(ctx context.Context, key, member string) error {
+	err := c.Client.SRem(ctx, key, member).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// TTL call redis TTL function
+func (c *standaloneClient) TTL(ctx context.Context, key string) (time.Duration, error) {
+	result, err := c.Client.TTL(ctx, key).Result()
+	if err != nil {
+		return -1, err
+	}
+
+	if result == -2 {
+		return -1, NewKeyNotFoundError(key)
+	}
+
+	if result == -1 {
+		return -1, NewTTLNotFoundError(key)
+	}
+
+	return result, nil
+}
+
+// ZAdd call redis ZADD function
+func (c *standaloneClient) ZAdd(ctx context.Context, key, member string, score float64) error {
+	err := c.Client.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Err()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ZCard call redis ZCARD function
+func (c *standaloneClient) ZCard(ctx context.Context, key string) (int64, error) {
+	result, err := c.Client.ZCard(ctx, key).Result()
+	if err != nil {
+		return -1, err
+	}
+
+	if result == 0 {
+		return -1, NewKeyNotFoundError(key)
+	}
+
+	return result, nil
+}
+
+// ZIncrBy call redis ZINCRBY function
+func (c *standaloneClient) ZIncrBy(ctx context.Context, key, member string, increment float64) error {
+	err := c.Client.ZIncrBy(ctx, key, increment, member).Err()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ZRange call redis ZRANGE function it is inclusive it returns start and stop element
+func (c *standaloneClient) ZRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
+	result, err := c.Client.ZRangeWithScores(ctx, key, start, stop).Result()
+	if err != nil {
+		return []*Member{}, err
+	}
+
+	var members []*Member = make([]*Member, 0, len(result))
+	for _, member := range result {
+		members = append(members, &Member{
+			Member: fmt.Sprint(member.Member),
+			Score:  member.Score,
+		})
+	}
+
+	return members, nil
+}
+
+// ZRank call redis ZRANK function
+func (c *standaloneClient) ZRank(ctx context.Context, key, member string) (int64, error) {
+	result, err := c.Client.ZRank(ctx, key, member).Result()
+	if err != nil {
+		if err.Error() == "redis: nil" {
+			return 0, NewMemberNotFoundError(key)
+		}
+
+		return 0, err
+	}
+
+	return result, nil
+}
+
+// ZRem call redis ZREM function
+func (c *standaloneClient) ZRem(ctx context.Context, key, member string) error {
+	err := c.Client.ZRem(ctx, key, member).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ZRevRange call redis ZREVRANGE function it is inclusive it returns start and stop element
+func (c *standaloneClient) ZRevRange(ctx context.Context, key string, start, stop int64) ([]*Member, error) {
+	result, err := c.Client.ZRevRangeWithScores(ctx, key, start, stop).Result()
+	if err != nil {
+		return []*Member{}, err
+	}
+
+	var members []*Member = make([]*Member, 0, len(result))
+	for _, member := range result {
+		members = append(members, &Member{
+			Member: fmt.Sprint(member.Member),
+			Score:  member.Score,
+		})
+	}
+
+	return members, nil
+}
+
+// ZRevRank call redis ZREVRANK function
+func (c *standaloneClient) ZRevRank(ctx context.Context, key, member string) (int64, error) {
+	result, err := c.Client.ZRevRank(ctx, key, member).Result()
+	if err != nil {
+		if err.Error() == "redis: nil" {
+			return 0, NewMemberNotFoundError(key)
+		}
+
+		return 0, err
+	}
+
+	return result, nil
+}
+
+// ZScore call redis ZScore function
+func (c *standaloneClient) ZScore(ctx context.Context, key, member string) (float64, error) {
+	result, err := c.Client.ZScore(ctx, key, member).Result()
+	if err != nil {
+		if err.Error() == "redis: nil" {
+			return 0, NewMemberNotFoundError(key)
+		}
+
+		return 0, err
+	}
+
+	return result, nil
+}

--- a/leaderboard/redis/standalone_client.go
+++ b/leaderboard/redis/standalone_client.go
@@ -82,7 +82,7 @@ func (c *standaloneClient) TTL(ctx context.Context, key string) (time.Duration, 
 		return -1, NewKeyNotFoundError(key)
 	}
 
-	if result == TTLNotFoundToKey {
+	if result == KeyWithoutTTL {
 		return -1, NewTTLNotFoundError(key)
 	}
 

--- a/leaderboard/redis/standalone_client.go
+++ b/leaderboard/redis/standalone_client.go
@@ -46,19 +46,13 @@ func (c *standaloneClient) ExpireAt(ctx context.Context, key string, time time.T
 // Ping call redis PING function
 func (c *standaloneClient) Ping(ctx context.Context) error {
 	err := c.Client.Ping(ctx).Err()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // SAdd call redis SADD function
 func (c *standaloneClient) SAdd(ctx context.Context, key, member string) error {
 	err := c.Client.SAdd(ctx, key, member).Err()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // SRem call redis SREM function
@@ -91,11 +85,7 @@ func (c *standaloneClient) TTL(ctx context.Context, key string) (time.Duration, 
 // ZAdd call redis ZADD function
 func (c *standaloneClient) ZAdd(ctx context.Context, key, member string, score float64) error {
 	err := c.Client.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Err()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ZCard call redis ZCARD function
@@ -115,11 +105,7 @@ func (c *standaloneClient) ZCard(ctx context.Context, key string) (int64, error)
 // ZIncrBy call redis ZINCRBY function
 func (c *standaloneClient) ZIncrBy(ctx context.Context, key, member string, increment float64) error {
 	err := c.Client.ZIncrBy(ctx, key, increment, member).Err()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ZRange call redis ZRANGE function it is inclusive it returns start and stop element
@@ -157,10 +143,7 @@ func (c *standaloneClient) ZRank(ctx context.Context, key, member string) (int64
 // ZRem call redis ZREM function
 func (c *standaloneClient) ZRem(ctx context.Context, key, member string) error {
 	err := c.Client.ZRem(ctx, key, member).Err()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // ZRevRange call redis ZREVRANGE function it is inclusive it returns start and stop element

--- a/leaderboard/redis/standalone_client_test.go
+++ b/leaderboard/redis/standalone_client_test.go
@@ -71,9 +71,10 @@ var _ = Describe("Standalone Client", func() {
 	})
 
 	Describe("Ping", func() {
-		It("Should return nil if redis is OK", func() {
-			err := standaloneClient.Ping(context.Background())
+		It("Should return PONG, nil if redis is OK", func() {
+			result, err := standaloneClient.Ping(context.Background())
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("PONG"))
 		})
 	})
 

--- a/leaderboard/redis/standalone_client_test.go
+++ b/leaderboard/redis/standalone_client_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Standalone Client", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(ttl).NotTo(Equal(redis.TTLKeyNotFound))
-			Expect(ttl).NotTo(Equal(redis.TTLNotFoundToKey))
+			Expect(ttl).NotTo(Equal(redis.KeyWithoutTTL))
 
 			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
 		})
@@ -117,8 +117,8 @@ var _ = Describe("Standalone Client", func() {
 			ttl, err := standaloneClient.TTL(context.Background(), testKey)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
-			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+			Expect(ttl).NotTo(Equal(redis.TTLKeyNotFound))
+			Expect(ttl).NotTo(Equal(redis.KeyWithoutTTL))
 
 			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
 		})

--- a/leaderboard/redis/standalone_client_test.go
+++ b/leaderboard/redis/standalone_client_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Leaderboard Model", func() {
 			ttl, err := goRedis.TTL(context.Background(), testKey).Result()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
-			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+			Expect(ttl).NotTo(Equal(redis.TTLKeyNotFound))
+			Expect(ttl).NotTo(Equal(redis.TTLNotFoundToKey))
 
 			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
 		})

--- a/leaderboard/redis/standalone_client_test.go
+++ b/leaderboard/redis/standalone_client_test.go
@@ -1,0 +1,336 @@
+package redis_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	goredis "github.com/go-redis/redis/v8"
+	"github.com/topfreegames/podium/leaderboard/redis"
+	"github.com/topfreegames/podium/leaderboard/testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Leaderboard Model", func() {
+	const testKey string = "testKey"
+	const member string = "member"
+
+	var standaloneClient redis.Redis
+	var goRedis *goredis.Client
+
+	BeforeEach(func() {
+		config, err := testing.GetDefaultConfig("../../config/test.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		standaloneClient = redis.NewStandaloneClient(redis.StandaloneOptions{
+			Host:     config.GetString("redis.host"),
+			Port:     config.GetInt("redis.port"),
+			Password: config.GetString("redis.password"),
+			DB:       config.GetInt("redis.db"),
+		})
+
+		goRedis = goredis.NewClient(&goredis.Options{
+			Addr:     fmt.Sprintf("%s:%s", config.GetString("redis.host"), config.GetString("redis.port")),
+			Password: config.GetString("redis.password"),
+			DB:       config.GetInt("redis.db"),
+		})
+	})
+
+	AfterEach(func() {
+		err := goRedis.Del(context.Background(), testKey).Err()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("ExpireAt", func() {
+		It("Should return nil if timeout is set", func() {
+			expirationTime := time.Now().Add(10 * time.Minute)
+
+			err := goRedis.Set(context.Background(), testKey, "testValue", 0).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = standaloneClient.ExpireAt(context.Background(), testKey, expirationTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			ttl, err := goRedis.TTL(context.Background(), testKey).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
+			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+
+			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
+		})
+
+		It("Should return KeyNotFound if key doesn't exists", func() {
+			expirationTime := time.Now().Add(10 * time.Minute)
+
+			err := standaloneClient.ExpireAt(context.Background(), testKey, expirationTime)
+			Expect(err).To(Equal(redis.NewKeyNotFoundError(testKey)))
+		})
+	})
+
+	Describe("Ping", func() {
+		It("Should return nil if redis is OK", func() {
+			err := standaloneClient.Ping(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("SAdd", func() {
+		It("Should return nil if member is add to set", func() {
+			err := standaloneClient.SAdd(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			isMember, err := goRedis.SIsMember(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(isMember).To(Equal(true))
+		})
+	})
+
+	Describe("SRem", func() {
+		It("Should return nil if member is removed from set", func() {
+			err := goRedis.SAdd(context.Background(), testKey, member).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = standaloneClient.SRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			isMember, err := goRedis.SIsMember(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(isMember).To(Equal(false))
+		})
+
+		It("Should return nil if set doesnt exists", func() {
+			err := standaloneClient.SRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("TTL", func() {
+		It("Should return time.Duration if key has TTL set", func() {
+			err := goRedis.Set(context.Background(), testKey, "testValue", 10*time.Minute).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			ttl, err := standaloneClient.TTL(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ttl).NotTo(Equal(-2)) // -2 = Key doesnt exists
+			Expect(ttl).NotTo(Equal(-1)) // -1  = Key exists but has no associated expire
+
+			Expect(ttl).Should(BeNumerically("~", 10*time.Minute, time.Minute))
+		})
+
+		It("Should return KeyNotFound if key doesn't exists", func() {
+			_, err := standaloneClient.TTL(context.Background(), testKey)
+			Expect(err).To(Equal(redis.NewKeyNotFoundError(testKey)))
+		})
+
+		It("Should return TTLNotFound if ttl was not set", func() {
+			err := goRedis.Set(context.Background(), testKey, "testValue", 0).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = standaloneClient.TTL(context.Background(), testKey)
+			Expect(err).To(Equal(redis.NewTTLNotFoundError(testKey)))
+		})
+	})
+
+	Describe("ZAdd", func() {
+		It("Should return nil if member is add to set", func() {
+			score := 1.0
+			err := standaloneClient.ZAdd(context.Background(), testKey, member, score)
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedScore, err := goRedis.ZScore(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedScore).To(Equal(score))
+		})
+	})
+
+	Describe("ZCard", func() {
+		It("Should return nil if member is add to set", func() {
+			member2 := "member2"
+
+			score := 1.0
+			score2 := 2.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}, &goredis.Z{Member: member2, Score: score2}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			count, err := standaloneClient.ZCard(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(count).To(BeEquivalentTo(2))
+		})
+	})
+
+	Describe("ZIncrBy", func() {
+		It("Should return nil if member is updated", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = standaloneClient.ZIncrBy(context.Background(), testKey, member, score)
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedScore, err := goRedis.ZScore(context.Background(), testKey, member).Result()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedScore).To(Equal(score + score))
+		})
+	})
+
+	Describe("ZRange", func() {
+		It("Should return members ordered by score, with respective scores", func() {
+			member2 := "member2"
+
+			score := 1.0
+			score2 := 2.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}, &goredis.Z{Member: member2, Score: score2}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			members, err := standaloneClient.ZRange(context.Background(), testKey, 0, -1)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(members[0].Member).To(Equal(member))
+			Expect(members[0].Score).To(Equal(score))
+
+			Expect(members[1].Member).To(Equal(member2))
+			Expect(members[1].Score).To(Equal(score2))
+		})
+	})
+
+	Describe("ZRank", func() {
+		It("Should return member rank and nil if no error ocurr", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			rank, err := standaloneClient.ZRank(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rank).To(BeEquivalentTo(0))
+		})
+
+		It("Should return error MemberNotFounderror if sorted set is empty", func() {
+			_, err := standaloneClient.ZRank(context.Background(), testKey, member)
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+
+		It("Should return error MemberNotFounderror if sorted set doesn't have member", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = standaloneClient.ZRank(context.Background(), testKey, "member not found")
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+	})
+
+	Describe("ZRem", func() {
+		It("Should return nil if member is removed from set", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = standaloneClient.ZRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = goRedis.ZRank(context.Background(), testKey, member).Result()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should return nil if set doesnt exists", func() {
+			err := standaloneClient.ZRem(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("ZRevRange", func() {
+		It("Should return members ordered by score, with respective scores", func() {
+			member2 := "member2"
+
+			score := 1.0
+			score2 := 2.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}, &goredis.Z{Member: member2, Score: score2}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			members, err := standaloneClient.ZRevRange(context.Background(), testKey, 0, -1)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(members[0].Member).To(Equal(member2))
+			Expect(members[0].Score).To(Equal(score2))
+
+			Expect(members[1].Member).To(Equal(member))
+			Expect(members[1].Score).To(Equal(score))
+		})
+	})
+
+	Describe("ZRevRank", func() {
+		It("Should return rank position if member is in set", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: "another-member", Score: score * 2.0}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedRank, err := standaloneClient.ZRevRank(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedRank).To(BeEquivalentTo(1))
+		})
+
+		It("Should return error MemberNotFounderror if sorted set is empty", func() {
+			_, err := standaloneClient.ZRevRank(context.Background(), testKey, member)
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+
+		It("Should return MemberNotFound if key doesn't have member", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: "another-member", Score: score * 2.0}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = standaloneClient.ZRevRank(context.Background(), testKey, "wrongKey")
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+	})
+
+	Describe("ZScore", func() {
+		It("Should return score if member is in set", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			returnedScore, err := standaloneClient.ZScore(context.Background(), testKey, member)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(returnedScore).To(Equal(score))
+		})
+
+		It("Should return MemberNotFound if key doesn't have member", func() {
+			score := 1.0
+
+			err := goRedis.ZAdd(context.Background(), testKey, &goredis.Z{Member: member, Score: score}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = standaloneClient.ZScore(context.Background(), testKey, "wrongKey")
+			Expect(err).To(Equal(redis.NewMemberNotFoundError(testKey)))
+		})
+	})
+})

--- a/leaderboard/redis/standalone_client_test.go
+++ b/leaderboard/redis/standalone_client_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Leaderboard Model", func() {
+var _ = Describe("Standalone Client", func() {
 	const testKey string = "testKey"
 	const member string = "member"
 


### PR DESCRIPTION
WHY
=======

Podium needs to support both Redis standalone and Redis cluster clients. To achieve this goal this PR proposes to create inside leaderboard a package to hold an interface to standardize the way to communicate with Redis. And two implementations `clusterClient` and `standaloneClient`.

WHAT WAS DONE
=======
* Create `leaderboard.Redis` interface to standardize Redis communication across all Podium
* Create `leaderboard.NewStandaloneClient` to instantiate a New Redis standalone client
* Create `leaderboard.NewClusterClient` to instantiate a New Redis Cluster client 