### PR TITLE
Create model member

### DIFF
--- a/leaderboard/model/member.go
+++ b/leaderboard/model/member.go
@@ -1,0 +1,10 @@
+package model
+
+// Member maps an member identified by their publicID to their score and rank
+type Member struct {
+	PublicID     string `json:"publicID"`
+	Score        int64  `json:"score"`
+	Rank         int    `json:"rank"`
+	PreviousRank int    `json:"previousRank"`
+	ExpireAt     int    `json:"expireAt"`
+}


### PR DESCRIPTION
WHY
======

To hold data structure that will be used across all leaderboard, the PR proposes to create `Member` model.

WHAT WAS DONE
======
* Create `Member` model