### PR TITLE
Fix leaderboard time broken test

### DIFF
--- a/api/leaderboard_test.go
+++ b/api/leaderboard_test.go
@@ -86,8 +86,8 @@ var _ = Describe("Leaderboard Handler", func() {
 				fmt.Sprintf("testkey-year%dweek%s", year, maybePrefixWithZero(week)),
 				fmt.Sprintf(
 					"testkey-year%dmonth%s",
-					time.Now().UTC().AddDate(0, -2, 0).Year(),
-					maybePrefixWithZero(int(time.Now().UTC().AddDate(0, -2, 0).Month())),
+					time.Now().UTC().AddDate(0, -3, 0).Year(),
+					maybePrefixWithZero(int(time.Now().UTC().AddDate(0, -3, 0).Month())),
 				),
 				fmt.Sprintf(
 					"testkey-year%dquarter0%d",


### PR DESCRIPTION
WHY
=======

Tests are broken because golang `time.Now().AddDate(0, -2, 0)` (04/20/2021) plus `previousTime.AddDate(0, 2, 0) is resulting in (05/01/2021) that is a valid expiration time and it is making test broken.

WHAT WAS DONE
=======
* Change test to use `time.Now().AddDate(0, -3, 0)` instead previous `-2`