### PR TITLE
Implement update members services

### DIFF
--- a/leaderboard/database/database.go
+++ b/leaderboard/database/database.go
@@ -7,6 +7,7 @@ import (
 
 // Database interface standardize database calls
 type Database interface {
+	GetLeaderboardExpiration(ctx context.Context, leaderboard string) (int64, error)
 	GetMemberIDsWithScoreInsideRange(ctx context.Context, leaderboard string, min, max string, offset, count int) ([]string, error)
 	GetMembers(ctx context.Context, leaderboard, order string, includeTTL bool, members ...string) ([]*Member, error)
 	GetOrderedMembers(ctx context.Context, leaderboard string, start, stop int, order string) ([]*Member, error)
@@ -15,6 +16,9 @@ type Database interface {
 	Healthcheck(ctx context.Context) error
 	RemoveLeaderboard(ctx context.Context, leaderboard string) error
 	RemoveMembers(ctx context.Context, leaderboard string, members ...string) error
+	SetLeaderboardExpiration(ctx context.Context, leaderboard string, expireAt time.Time) error
+	SetMembers(ctx context.Context, leaderboard string, databaseMembers []*Member) error
+	SetMembersTTL(ctx context.Context, leaderboard string, databaseMembers []*Member) error
 }
 
 // Member is a struct to be used by users operations

--- a/leaderboard/database/database.go
+++ b/leaderboard/database/database.go
@@ -14,6 +14,7 @@ type Database interface {
 	GetRank(ctx context.Context, leaderboard, member, order string) (int, error)
 	GetTotalMembers(ctx context.Context, leaderboard string) (int, error)
 	Healthcheck(ctx context.Context) error
+	IncrementMemberScore(ctx context.Context, leaderboard, member string, increment float64) error
 	RemoveLeaderboard(ctx context.Context, leaderboard string) error
 	RemoveMembers(ctx context.Context, leaderboard string, members ...string) error
 	SetLeaderboardExpiration(ctx context.Context, leaderboard string, expireAt time.Time) error

--- a/leaderboard/database/database.go
+++ b/leaderboard/database/database.go
@@ -1,6 +1,9 @@
 package database
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Database interface standardize database calls
 type Database interface {
@@ -19,5 +22,5 @@ type Member struct {
 	Member string
 	Score  float64
 	Rank   int64
-	TTL    float64
+	TTL    time.Time
 }

--- a/leaderboard/database/errors.go
+++ b/leaderboard/database/errors.go
@@ -49,3 +49,19 @@ func NewMemberNotFoundError(leaderboard, member string) *MemberNotFoundError {
 		member:      member,
 	}
 }
+
+// TTLNotFoundError is an error throw when key has not TTL
+type TTLNotFoundError struct {
+	leaderboard string
+}
+
+// NewTTLNotFoundError create a new KeyNotFoundError
+func NewTTLNotFoundError(leaderboard string) *TTLNotFoundError {
+	return &TTLNotFoundError{
+		leaderboard: leaderboard,
+	}
+}
+
+func (tnfe *TTLNotFoundError) Error() string {
+	return fmt.Sprintf("ttl to leaderboard %s not found", tnfe.leaderboard)
+}

--- a/leaderboard/database/mock.go
+++ b/leaderboard/database/mock.go
@@ -144,6 +144,20 @@ func (mr *MockDatabaseMockRecorder) Healthcheck(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Healthcheck", reflect.TypeOf((*MockDatabase)(nil).Healthcheck), ctx)
 }
 
+// IncrementMemberScore mocks base method.
+func (m *MockDatabase) IncrementMemberScore(ctx context.Context, leaderboard, member string, increment float64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IncrementMemberScore", ctx, leaderboard, member, increment)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IncrementMemberScore indicates an expected call of IncrementMemberScore.
+func (mr *MockDatabaseMockRecorder) IncrementMemberScore(ctx, leaderboard, member, increment interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrementMemberScore", reflect.TypeOf((*MockDatabase)(nil).IncrementMemberScore), ctx, leaderboard, member, increment)
+}
+
 // RemoveLeaderboard mocks base method.
 func (m *MockDatabase) RemoveLeaderboard(ctx context.Context, leaderboard string) error {
 	m.ctrl.T.Helper()

--- a/leaderboard/database/mock.go
+++ b/leaderboard/database/mock.go
@@ -35,6 +35,21 @@ func (m *MockDatabase) EXPECT() *MockDatabaseMockRecorder {
 	return m.recorder
 }
 
+// GetLeaderboardExpiration mocks base method.
+func (m *MockDatabase) GetLeaderboardExpiration(ctx context.Context, leaderboard string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLeaderboardExpiration", ctx, leaderboard)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLeaderboardExpiration indicates an expected call of GetLeaderboardExpiration.
+func (mr *MockDatabaseMockRecorder) GetLeaderboardExpiration(ctx, leaderboard interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLeaderboardExpiration", reflect.TypeOf((*MockDatabase)(nil).GetLeaderboardExpiration), ctx, leaderboard)
+}
+
 // GetMemberIDsWithScoreInsideRange mocks base method.
 func (m *MockDatabase) GetMemberIDsWithScoreInsideRange(ctx context.Context, leaderboard, min, max string, offset, count int) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -160,4 +175,46 @@ func (mr *MockDatabaseMockRecorder) RemoveMembers(ctx, leaderboard interface{}, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, leaderboard}, members...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMembers", reflect.TypeOf((*MockDatabase)(nil).RemoveMembers), varargs...)
+}
+
+// SetLeaderboardExpiration mocks base method.
+func (m *MockDatabase) SetLeaderboardExpiration(ctx context.Context, leaderboard string, expireAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLeaderboardExpiration", ctx, leaderboard, expireAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLeaderboardExpiration indicates an expected call of SetLeaderboardExpiration.
+func (mr *MockDatabaseMockRecorder) SetLeaderboardExpiration(ctx, leaderboard, expireAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLeaderboardExpiration", reflect.TypeOf((*MockDatabase)(nil).SetLeaderboardExpiration), ctx, leaderboard, expireAt)
+}
+
+// SetMembers mocks base method.
+func (m *MockDatabase) SetMembers(ctx context.Context, leaderboard string, databaseMembers []*Member) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMembers", ctx, leaderboard, databaseMembers)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMembers indicates an expected call of SetMembers.
+func (mr *MockDatabaseMockRecorder) SetMembers(ctx, leaderboard, databaseMembers interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMembers", reflect.TypeOf((*MockDatabase)(nil).SetMembers), ctx, leaderboard, databaseMembers)
+}
+
+// SetMembersTTL mocks base method.
+func (m *MockDatabase) SetMembersTTL(ctx context.Context, leaderboard string, databaseMembers []*Member) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMembersTTL", ctx, leaderboard, databaseMembers)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMembersTTL indicates an expected call of SetMembersTTL.
+func (mr *MockDatabaseMockRecorder) SetMembersTTL(ctx, leaderboard, databaseMembers interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMembersTTL", reflect.TypeOf((*MockDatabase)(nil).SetMembersTTL), ctx, leaderboard, databaseMembers)
 }

--- a/leaderboard/database/mock.go
+++ b/leaderboard/database/mock.go
@@ -7,6 +7,7 @@ package database
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 )

--- a/leaderboard/database/redis.go
+++ b/leaderboard/database/redis.go
@@ -207,6 +207,15 @@ func (r *Redis) Healthcheck(ctx context.Context) error {
 	return nil
 }
 
+// IncrementMemberScore add to member score the value in parameter
+func (r *Redis) IncrementMemberScore(ctx context.Context, leaderboard, member string, increment float64) error {
+	err := r.ZIncrBy(ctx, leaderboard, member, increment)
+	if err != nil {
+		return NewGeneralError(err.Error())
+	}
+	return nil
+}
+
 // RemoveLeaderboard delete leaderboard key from redis
 func (r *Redis) RemoveLeaderboard(ctx context.Context, leaderboard string) error {
 	err := r.Redis.Del(ctx, leaderboard)

--- a/leaderboard/database/redis/cluster_client.go
+++ b/leaderboard/database/redis/cluster_client.go
@@ -99,8 +99,16 @@ func (cc *clusterClient) TTL(ctx context.Context, key string) (time.Duration, er
 }
 
 // ZAdd call redis ZADD function
-func (cc *clusterClient) ZAdd(ctx context.Context, key, member string, score float64) error {
-	err := cc.ClusterClient.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Err()
+func (cc *clusterClient) ZAdd(ctx context.Context, key string, members ...*Member) error {
+	goRedisMembers := make([]*goredis.Z, 0, len(members))
+	for _, member := range members {
+		goRedisMembers = append(goRedisMembers, &goredis.Z{
+			Member: member.Member,
+			Score:  member.Score,
+		})
+	}
+
+	err := cc.ClusterClient.ZAdd(ctx, key, goRedisMembers...).Err()
 	if err != nil {
 		return NewGeneralError(err.Error())
 	}

--- a/leaderboard/database/redis/cluster_client_test.go
+++ b/leaderboard/database/redis/cluster_client_test.go
@@ -158,7 +158,17 @@ var _ = Describe("Cluster Client", func() {
 	Describe("ZAdd", func() {
 		It("Should return nil if member is add to set", func() {
 			score := 1.0
-			err := clusterClient.ZAdd(context.Background(), testKey, member, score)
+			members := []*redis.Member{
+				&redis.Member{
+					Member: member,
+					Score:  score,
+				},
+				&redis.Member{
+					Member: "member2",
+					Score:  2.0,
+				},
+			}
+			err := clusterClient.ZAdd(context.Background(), testKey, members...)
 			Expect(err).NotTo(HaveOccurred())
 
 			returnedScore, err := goRedis.ZScore(context.Background(), testKey, member).Result()

--- a/leaderboard/database/redis/cluster_client_test.go
+++ b/leaderboard/database/redis/cluster_client_test.go
@@ -159,11 +159,11 @@ var _ = Describe("Cluster Client", func() {
 		It("Should return nil if member is add to set", func() {
 			score := 1.0
 			members := []*redis.Member{
-				&redis.Member{
+				{
 					Member: member,
 					Score:  score,
 				},
-				&redis.Member{
+				{
 					Member: "member2",
 					Score:  2.0,
 				},

--- a/leaderboard/database/redis/errors.go
+++ b/leaderboard/database/redis/errors.go
@@ -31,7 +31,7 @@ func NewTTLNotFoundError(key string) *TTLNotFoundError {
 }
 
 func (knfe *TTLNotFoundError) Error() string {
-	return fmt.Sprintf("redis key %s not found", knfe.key)
+	return fmt.Sprintf("redis ttl to key %s not found", knfe.key)
 }
 
 // MemberNotFoundError is an error throw when key has not Member

--- a/leaderboard/database/redis/mock.go
+++ b/leaderboard/database/redis/mock.go
@@ -122,17 +122,22 @@ func (mr *MockRedisMockRecorder) TTL(ctx, key interface{}) *gomock.Call {
 }
 
 // ZAdd mocks base method.
-func (m *MockRedis) ZAdd(ctx context.Context, key, member string, score float64) error {
+func (m *MockRedis) ZAdd(ctx context.Context, key string, members ...*Member) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ZAdd", ctx, key, member, score)
+	varargs := []interface{}{ctx, key}
+	for _, a := range members {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ZAdd", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ZAdd indicates an expected call of ZAdd.
-func (mr *MockRedisMockRecorder) ZAdd(ctx, key, member, score interface{}) *gomock.Call {
+func (mr *MockRedisMockRecorder) ZAdd(ctx, key interface{}, members ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ZAdd", reflect.TypeOf((*MockRedis)(nil).ZAdd), ctx, key, member, score)
+	varargs := append([]interface{}{ctx, key}, members...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ZAdd", reflect.TypeOf((*MockRedis)(nil).ZAdd), varargs...)
 }
 
 // ZCard mocks base method.

--- a/leaderboard/database/redis/redis.go
+++ b/leaderboard/database/redis/redis.go
@@ -20,7 +20,7 @@ type Redis interface {
 	SAdd(ctx context.Context, key, member string) error
 	SRem(ctx context.Context, key, member string) error
 	TTL(ctx context.Context, key string) (time.Duration, error)
-	ZAdd(ctx context.Context, key, member string, score float64) error
+	ZAdd(ctx context.Context, key string, members ...*Member) error
 	ZCard(ctx context.Context, key string) (int64, error)
 	ZIncrBy(ctx context.Context, key, member string, increment float64) error
 	ZRange(ctx context.Context, key string, start, stop int64) ([]*Member, error)

--- a/leaderboard/database/redis/standalone_client.go
+++ b/leaderboard/database/redis/standalone_client.go
@@ -102,8 +102,15 @@ func (c *standaloneClient) TTL(ctx context.Context, key string) (time.Duration, 
 }
 
 // ZAdd call redis ZADD function
-func (c *standaloneClient) ZAdd(ctx context.Context, key, member string, score float64) error {
-	err := c.Client.ZAdd(ctx, key, &goredis.Z{Score: score, Member: member}).Err()
+func (c *standaloneClient) ZAdd(ctx context.Context, key string, members ...*Member) error {
+	goRedisMembers := make([]*goredis.Z, 0, len(members))
+	for _, member := range members {
+		goRedisMembers = append(goRedisMembers, &goredis.Z{
+			Member: member.Member,
+			Score:  member.Score,
+		})
+	}
+	err := c.Client.ZAdd(ctx, key, goRedisMembers...).Err()
 	if err != nil {
 		return NewGeneralError(err.Error())
 	}

--- a/leaderboard/database/redis/standalone_client_test.go
+++ b/leaderboard/database/redis/standalone_client_test.go
@@ -162,11 +162,11 @@ var _ = Describe("Standalone Client", func() {
 		It("Should return nil if members is add to set", func() {
 			score := 1.0
 			members := []*redis.Member{
-				&redis.Member{
+				{
 					Member: member,
 					Score:  score,
 				},
-				&redis.Member{
+				{
 					Member: "member2",
 					Score:  2.0,
 				},

--- a/leaderboard/database/redis/standalone_client_test.go
+++ b/leaderboard/database/redis/standalone_client_test.go
@@ -159,9 +159,19 @@ var _ = Describe("Standalone Client", func() {
 	})
 
 	Describe("ZAdd", func() {
-		It("Should return nil if member is add to set", func() {
+		It("Should return nil if members is add to set", func() {
 			score := 1.0
-			err := standaloneClient.ZAdd(context.Background(), testKey, member, score)
+			members := []*redis.Member{
+				&redis.Member{
+					Member: member,
+					Score:  score,
+				},
+				&redis.Member{
+					Member: "member2",
+					Score:  2.0,
+				},
+			}
+			err := standaloneClient.ZAdd(context.Background(), testKey, members...)
 			Expect(err).NotTo(HaveOccurred())
 
 			returnedScore, err := goRedis.ZScore(context.Background(), testKey, member).Result()

--- a/leaderboard/database/redis_test.go
+++ b/leaderboard/database/redis_test.go
@@ -3,6 +3,7 @@ package database_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -18,6 +19,7 @@ var _ = Describe("Redis Database", func() {
 	var leaderboard string = "leaderboardTest"
 	var leaderboardTTL string = "leaderboardTest:ttl"
 	var member string = "memberTest"
+	var score float64 = 1.0
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
@@ -44,13 +46,13 @@ var _ = Describe("Redis Database", func() {
 							Member: "member1",
 							Score:  float64(1),
 							Rank:   int64(0),
-							TTL:    float64(10000),
+							TTL:    time.Unix(10000, 0),
 						},
 						&database.Member{
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -75,13 +77,13 @@ var _ = Describe("Redis Database", func() {
 							Member: "member1",
 							Score:  float64(1),
 							Rank:   int64(0),
-							TTL:    float64(10000),
+							TTL:    time.Unix(10000, 0),
 						},
 						&database.Member{
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -107,7 +109,7 @@ var _ = Describe("Redis Database", func() {
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(10000),
+							TTL:    time.Unix(10000, 0),
 						},
 					}
 
@@ -142,13 +144,13 @@ var _ = Describe("Redis Database", func() {
 							Member: "member1",
 							Score:  float64(1),
 							Rank:   int64(0),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 						&database.Member{
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -164,19 +166,19 @@ var _ = Describe("Redis Database", func() {
 					Expect(members).To(Equal(expectedMembers))
 				})
 
-				It("Should return member list with TTL equals zero if redis return ok", func() {
+				It("Should return member list with empty TTL if redis return ok", func() {
 					expectedMembers := []*database.Member{
 						&database.Member{
 							Member: "member1",
 							Score:  float64(1),
 							Rank:   int64(0),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 						&database.Member{
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -199,7 +201,7 @@ var _ = Describe("Redis Database", func() {
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -236,13 +238,13 @@ var _ = Describe("Redis Database", func() {
 							Member: "member1",
 							Score:  float64(2),
 							Rank:   int64(0),
-							TTL:    float64(10000),
+							TTL:    time.Unix(10000, 0),
 						},
 						&database.Member{
 							Member: "member2",
 							Score:  float64(1),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -268,7 +270,7 @@ var _ = Describe("Redis Database", func() {
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(10000),
+							TTL:    time.Unix(10000, 0),
 						},
 					}
 
@@ -303,13 +305,13 @@ var _ = Describe("Redis Database", func() {
 							Member: "member1",
 							Score:  float64(2),
 							Rank:   int64(0),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 						&database.Member{
 							Member: "member2",
 							Score:  float64(1),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -332,7 +334,7 @@ var _ = Describe("Redis Database", func() {
 							Member: "member2",
 							Score:  float64(2),
 							Rank:   int64(1),
-							TTL:    float64(0),
+							TTL:    time.Time{},
 						},
 					}
 
@@ -607,7 +609,7 @@ var _ = Describe("Redis Database", func() {
 	})
 
 	Describe("RemoveLeaderboard", func() {
-		It("Should return nil if no error occur", func() {
+		It("Should return nil if no error happended", func() {
 			mock.EXPECT().Del(gomock.Any(), gomock.Eq(leaderboard)).Return(nil)
 
 			err := redisDatabase.RemoveLeaderboard(context.Background(), leaderboard)

--- a/leaderboard/interface.go
+++ b/leaderboard/interface.go
@@ -10,7 +10,7 @@ import (
 type Leaderboard interface {
 	Healthcheck(ctx context.Context) error
 
-	// IncrementMemberScore(ctx context.Context, leaderboard string, member string, increment int, scoreTTL string) (*model.Member, error)
+	IncrementMemberScore(ctx context.Context, leaderboard string, member string, increment int, scoreTTL string) (*model.Member, error)
 	SetMemberScore(ctx context.Context, leaderboard, member string, score int64, prevRank bool, scoreTTL string) (*model.Member, error)
 	SetMembersScore(ctx context.Context, leaderboard string, members []*model.Member, prevRank bool, scoreTTL string) error
 

--- a/leaderboard/interface.go
+++ b/leaderboard/interface.go
@@ -12,7 +12,7 @@ type Leaderboard interface {
 
 	// IncrementMemberScore(ctx context.Context, leaderboard string, member string, increment int, scoreTTL string) (*model.Member, error)
 	// SetMemberScore(ctx context.Context, leadeboard, member string, score int64, prevRank bool, scoreTTL string) (*model.Member, error)
-	// SetMembersScore(ctx context.Context, leaderboardID string, members []*model.Member, prevRank bool, scoreTTL string) error
+	SetMembersScore(ctx context.Context, leaderboard string, members []*model.Member, prevRank bool, scoreTTL string) error
 
 	RemoveLeaderboard(ctx context.Context, leaderboard string) error
 	RemoveMember(ctx context.Context, leaderboard, member string) error
@@ -31,5 +31,5 @@ type Leaderboard interface {
 
 	GetAroundMe(ctx context.Context, leaderboard string, pageSize int, member string, order string, getLastIfNotFound bool) ([]*model.Member, error)
 
-	GetAroundScore(ctx context.Context, leaderboardID string, pageSize int, score int64, order string) ([]*model.Member, error)
+	GetAroundScore(ctx context.Context, leaderboard string, pageSize int, score int64, order string) ([]*model.Member, error)
 }

--- a/leaderboard/interface.go
+++ b/leaderboard/interface.go
@@ -11,7 +11,7 @@ type Leaderboard interface {
 	Healthcheck(ctx context.Context) error
 
 	// IncrementMemberScore(ctx context.Context, leaderboard string, member string, increment int, scoreTTL string) (*model.Member, error)
-	// SetMemberScore(ctx context.Context, leadeboard, member string, score int64, prevRank bool, scoreTTL string) (*model.Member, error)
+	SetMemberScore(ctx context.Context, leaderboard, member string, score int64, prevRank bool, scoreTTL string) (*model.Member, error)
 	SetMembersScore(ctx context.Context, leaderboard string, members []*model.Member, prevRank bool, scoreTTL string) error
 
 	RemoveLeaderboard(ctx context.Context, leaderboard string) error

--- a/leaderboard/service/get_member.go
+++ b/leaderboard/service/get_member.go
@@ -23,6 +23,6 @@ func (s *Service) GetMember(ctx context.Context, leaderboard, member string, ord
 		PublicID: databaseMembers[0].Member,
 		Score:    int64(databaseMembers[0].Score),
 		Rank:     int(databaseMembers[0].Rank) + 1,
-		ExpireAt: int(databaseMembers[0].TTL),
+		ExpireAt: int(databaseMembers[0].TTL.Unix()),
 	}, nil
 }

--- a/leaderboard/service/get_member_test.go
+++ b/leaderboard/service/get_member_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -39,7 +40,7 @@ var _ = Describe("Service GetMember", func() {
 				Member: "member1",
 				Score:  float64(1),
 				Rank:   int64(0),
-				TTL:    float64(10000),
+				TTL:    time.Unix(10000, 0),
 			},
 		}
 

--- a/leaderboard/service/get_members.go
+++ b/leaderboard/service/get_members.go
@@ -25,7 +25,7 @@ func (s *Service) GetMembers(ctx context.Context, leaderboard string, members []
 			PublicID: member.Member,
 			Score:    int64(member.Score),
 			Rank:     int(member.Rank) + 1,
-			ExpireAt: int(member.TTL),
+			ExpireAt: int(member.TTL.Unix()),
 		}
 		membersToReturn = append(membersToReturn, newMember)
 

--- a/leaderboard/service/get_members_test.go
+++ b/leaderboard/service/get_members_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -39,14 +40,14 @@ var _ = Describe("Service GetMembers", func() {
 				Member: "member1",
 				Score:  float64(1),
 				Rank:   int64(0),
-				TTL:    float64(10000),
+				TTL:    time.Unix(10000, 0),
 			},
 			nil,
 			&database.Member{
 				Member: "member3",
 				Score:  float64(3),
 				Rank:   int64(1),
-				TTL:    float64(10001),
+				TTL:    time.Unix(10001, 0),
 			},
 		}
 

--- a/leaderboard/service/increment_member_score.go
+++ b/leaderboard/service/increment_member_score.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+
+	"github.com/topfreegames/podium/leaderboard/model"
+)
+
+const incrementMemberScoreServiceLabel = "increment member score"
+
+const incrementMemberOrder = "desc"
+
+// IncrementMemberScore return member informations that had you score incremented
+func (s *Service) IncrementMemberScore(ctx context.Context, leaderboard string, member string, increment int, scoreTTL string) (*model.Member, error) {
+	modelMember := &model.Member{
+		PublicID: member,
+		Score:    int64(increment),
+	}
+
+	err := s.incrementMember(ctx, leaderboard, member, increment)
+	if err != nil {
+		return nil, NewGeneralError(incrementMemberScoreServiceLabel, err.Error())
+	}
+
+	members := []*model.Member{modelMember}
+
+	err = s.setMembersRank(ctx, leaderboard, members, incrementMemberOrder)
+	if err != nil {
+		return nil, NewGeneralError(incrementMemberScoreServiceLabel, err.Error())
+	}
+
+	err = s.persistLeaderboardExpirationTime(ctx, leaderboard)
+	if err != nil {
+		return nil, NewGeneralError(incrementMemberScoreServiceLabel, err.Error())
+	}
+
+	if scoreTTL != "" {
+		err = s.persistMembersTTL(ctx, leaderboard, members, scoreTTL)
+		if err != nil {
+			return nil, NewGeneralError(incrementMemberScoreServiceLabel, err.Error())
+		}
+	}
+
+	return modelMember, nil
+}
+
+func (s *Service) incrementMember(ctx context.Context, leaderboard, member string, increment int) error {
+	return s.Database.IncrementMemberScore(ctx, leaderboard, member, float64(increment))
+}

--- a/leaderboard/service/increment_member_score_test.go
+++ b/leaderboard/service/increment_member_score_test.go
@@ -1,0 +1,196 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/topfreegames/podium/leaderboard/database"
+	"github.com/topfreegames/podium/leaderboard/expiration"
+	"github.com/topfreegames/podium/leaderboard/model"
+	"github.com/topfreegames/podium/leaderboard/service"
+)
+
+var _ = Describe("Service SetMemberScore", func() {
+	var ctrl *gomock.Controller
+	var mock *database.MockDatabase
+	var svc *service.Service
+
+	var leaderboard string = "leaderboard"
+	var member string = "member1"
+	var score int = 1.0
+	var scoreTTL string = ""
+
+	databaseMembersReturned := []*database.Member{
+		{
+			Member: "member1",
+			Score:  1.0,
+			Rank:   int64(1),
+		},
+	}
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mock = database.NewMockDatabase(ctrl)
+
+		svc = &service.Service{mock}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("When scoreTTL is empty", func() {
+		It("Should SetMembers without filling expire ordered set", func() {
+			expectedMember := &model.Member{
+				PublicID:     "member1",
+				Score:        1,
+				PreviousRank: 0,
+				Rank:         2,
+			}
+
+			mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(float64(score))).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(member),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			member, err := svc.IncrementMemberScore(context.Background(), leaderboard, member, score, scoreTTL)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(member).To(Equal(expectedMember))
+		})
+	})
+
+	Describe("When scoreTTL is set", func() {
+		scoreTTL := "100"
+
+		It("Should SetMembers filling expire ordered set", func() {
+			mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(float64(score))).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(member),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			mock.EXPECT().SetMembersTTL(gomock.Any(), gomock.Eq(leaderboard), gomock.Any()).Times(1).Return(nil)
+
+			member, err := svc.IncrementMemberScore(context.Background(), leaderboard, member, score, scoreTTL)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(member.ExpireAt).To(BeNumerically("~", time.Now().Add(100*time.Second).Unix(), 100))
+		})
+	})
+
+	Describe("When scoreTTL is invalid", func() {
+		scoreTTL := "invalid"
+
+		It("Should return error", func() {
+			mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(float64(score))).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(member),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			_, err := svc.IncrementMemberScore(context.Background(), leaderboard, member, score, scoreTTL)
+			Expect(err).To(MatchError(service.NewGeneralError("increment member score", "strconv.ParseInt: parsing \"invalid\": invalid syntax")))
+
+		})
+	})
+
+	It("Should return error if database SetMembers return in error", func() {
+		mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(float64(score))).Return(fmt.Errorf("New database error"))
+
+		_, err := svc.IncrementMemberScore(context.Background(), leaderboard, member, score, scoreTTL)
+		Expect(err).To(MatchError(service.NewGeneralError("increment member score", "New database error")))
+	})
+
+	It("Should return error if database GetMembers return in error", func() {
+		mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(float64(score))).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboard),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(member),
+		).Return(nil, fmt.Errorf("New database error"))
+
+		_, err := svc.IncrementMemberScore(context.Background(), leaderboard, member, score, scoreTTL)
+		Expect(err).To(MatchError(service.NewGeneralError("increment member score", "New database error")))
+
+	})
+
+	It("Should set leaderboard expiration if GetLeaderboardExpiration return TTLNotFoundError", func() {
+		leaderboardExpiration := fmt.Sprintf("year%d", time.Now().UTC().Year())
+		expireAt, err := expiration.GetExpireAt(leaderboardExpiration)
+		Expect(err).NotTo(HaveOccurred())
+
+		mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboardExpiration), gomock.Eq(member), gomock.Eq(float64(score))).Times(1).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboardExpiration),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(member),
+		).Return(databaseMembersReturned, nil)
+		mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration)).Return(int64(-1), database.NewTTLNotFoundError(leaderboard))
+
+		mock.EXPECT().SetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration), time.Unix(expireAt, 0)).Return(nil)
+
+		_, err = svc.IncrementMemberScore(context.Background(), leaderboardExpiration, member, score, scoreTTL)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should return error if database GetLeaderboardExpiration return in error", func() {
+		leaderboardExpiration := fmt.Sprintf("year%d", time.Now().UTC().Year())
+
+		mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboardExpiration), gomock.Eq(member), gomock.Eq(float64(score))).Times(1).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboardExpiration),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(member),
+		).Return(databaseMembersReturned, nil)
+		mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration)).Return(int64(-1), fmt.Errorf("New database error"))
+
+		_, err := svc.IncrementMemberScore(context.Background(), leaderboardExpiration, member, score, scoreTTL)
+		Expect(err).To(MatchError(service.NewGeneralError("increment member score", "New database error")))
+	})
+
+	It("Should return error if database SetLeaderboardExpiration return in error", func() {
+		leaderboardExpiration := fmt.Sprintf("year%d", time.Now().UTC().Year())
+		expireAt, err := expiration.GetExpireAt(leaderboardExpiration)
+		Expect(err).NotTo(HaveOccurred())
+
+		mock.EXPECT().IncrementMemberScore(gomock.Any(), gomock.Eq(leaderboardExpiration), gomock.Eq(member), gomock.Eq(float64(score))).Times(1).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboardExpiration),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(member),
+		).Return(databaseMembersReturned, nil)
+		mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration)).Return(int64(-1), database.NewTTLNotFoundError(leaderboard))
+
+		mock.EXPECT().SetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration), time.Unix(expireAt, 0)).Return(fmt.Errorf("New database error"))
+
+		_, err = svc.IncrementMemberScore(context.Background(), leaderboardExpiration, member, score, scoreTTL)
+		Expect(err).To(MatchError(service.NewGeneralError("increment member score", "New database error")))
+	})
+
+})

--- a/leaderboard/service/leadeboard.go
+++ b/leaderboard/service/leadeboard.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/topfreegames/podium/leaderboard/database"
+	"github.com/topfreegames/podium/leaderboard/expiration"
+)
+
+func (s *Service) persistLeaderboardExpirationTime(ctx context.Context, leaderboard string) error {
+	expireAt, err := expiration.GetExpireAt(leaderboard)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.Database.GetLeaderboardExpiration(ctx, leaderboard)
+	if err != nil {
+		if _, ok := err.(*database.TTLNotFoundError); ok {
+			err = s.Database.SetLeaderboardExpiration(ctx, leaderboard, time.Unix(expireAt, 0))
+			if err != nil {
+				return err
+			}
+
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/leaderboard/service/members.go
+++ b/leaderboard/service/members.go
@@ -92,20 +92,6 @@ func (s *Service) setMembersRank(ctx context.Context, leaderboard string, member
 	return nil
 }
 
-func (s *Service) getDatabaseMembers(ctx context.Context, leaderboard string, members []*model.Member, order string) ([]*database.Member, error) {
-	memberIDs := make([]string, 0, len(members))
-	for _, member := range members {
-		memberIDs = append(memberIDs, member.PublicID)
-	}
-
-	databaseMembers, err := s.Database.GetMembers(ctx, leaderboard, order, true, memberIDs...)
-	if err != nil {
-		return nil, err
-	}
-
-	return databaseMembers, nil
-}
-
 func (s *Service) persistMembersTTL(ctx context.Context, leaderboard string, members []*model.Member, scoreTTL string) error {
 	ttl, err := strconv.ParseInt(scoreTTL, 10, 64)
 	if err != nil {
@@ -130,4 +116,18 @@ func (s *Service) persistMembersTTL(ctx context.Context, leaderboard string, mem
 
 	return nil
 
+}
+
+func (s *Service) getDatabaseMembers(ctx context.Context, leaderboard string, members []*model.Member, order string) ([]*database.Member, error) {
+	memberIDs := make([]string, 0, len(members))
+	for _, member := range members {
+		memberIDs = append(memberIDs, member.PublicID)
+	}
+
+	databaseMembers, err := s.Database.GetMembers(ctx, leaderboard, order, true, memberIDs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return databaseMembers, nil
 }

--- a/leaderboard/service/members.go
+++ b/leaderboard/service/members.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"strconv"
+	"time"
 
 	"github.com/topfreegames/podium/leaderboard/database"
 	"github.com/topfreegames/podium/leaderboard/model"
@@ -43,4 +45,89 @@ func (s *Service) fetchMemberRank(ctx context.Context, leaderboard, member, orde
 	}
 
 	return memberRank, nil
+}
+
+func (s *Service) setMembersPreviousRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
+	databaseMembers, err := s.getDatabaseMembers(ctx, leaderboard, members, order)
+	if err != nil {
+		return err
+	}
+
+	for i, member := range members {
+		if databaseMembers[i] != nil {
+			member.PreviousRank = int(databaseMembers[i].Rank + 1)
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) persistMembers(ctx context.Context, leaderboard string, members []*model.Member) error {
+	databaseMembers := make([]*database.Member, 0, len(members))
+	for _, member := range members {
+		databaseMembers = append(databaseMembers, &database.Member{
+			Member: member.PublicID,
+			Score:  float64(member.Score),
+		})
+	}
+
+	err := s.Database.SetMembers(ctx, leaderboard, databaseMembers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) setMembersRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
+	databaseMembers, err := s.getDatabaseMembers(ctx, leaderboard, members, order)
+	if err != nil {
+		return err
+	}
+
+	for i, member := range databaseMembers {
+		members[i].Rank = int(member.Rank + 1)
+	}
+
+	return nil
+}
+
+func (s *Service) getDatabaseMembers(ctx context.Context, leaderboard string, members []*model.Member, order string) ([]*database.Member, error) {
+	memberIDs := make([]string, 0, len(members))
+	for _, member := range members {
+		memberIDs = append(memberIDs, member.PublicID)
+	}
+
+	databaseMembers, err := s.Database.GetMembers(ctx, leaderboard, order, true, memberIDs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return databaseMembers, nil
+}
+
+func (s *Service) persistMembersTTL(ctx context.Context, leaderboard string, members []*model.Member, scoreTTL string) error {
+	ttl, err := strconv.ParseInt(scoreTTL, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	timeToExpire := time.Now().UTC().Add(time.Duration(ttl) * time.Second)
+
+	databaseMembers := make([]*database.Member, 0, len(members))
+	for _, member := range members {
+		databaseMembers = append(databaseMembers, &database.Member{
+			Member: member.PublicID,
+			TTL:    timeToExpire,
+		})
+		member.ExpireAt = int(timeToExpire.Unix())
+	}
+
+	err = s.Database.SetMembersTTL(ctx, leaderboard, databaseMembers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
 }

--- a/leaderboard/service/set_member_score.go
+++ b/leaderboard/service/set_member_score.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+
+	"github.com/topfreegames/podium/leaderboard/model"
+)
+
+const setMemberScoreServiceLabel = "set member score"
+
+const setMemberOrder = "desc"
+
+// SetMemberScore return member informations that is
+func (s *Service) SetMemberScore(ctx context.Context, leaderboard, member string, score int64, prevRank bool, scoreTTL string) (*model.Member, error) {
+	members := []*model.Member{
+		{
+			PublicID: member,
+			Score:    score,
+		},
+	}
+
+	if prevRank {
+		err := s.setMembersPreviousRank(ctx, leaderboard, members, setMemberOrder)
+		if err != nil {
+			return nil, NewGeneralError(setMemberScoreServiceLabel, err.Error())
+		}
+	}
+
+	err := s.persistMembers(ctx, leaderboard, members)
+	if err != nil {
+		return nil, NewGeneralError(setMemberScoreServiceLabel, err.Error())
+	}
+
+	err = s.setMembersRank(ctx, leaderboard, members, setMemberOrder)
+	if err != nil {
+		return nil, NewGeneralError(setMemberScoreServiceLabel, err.Error())
+	}
+
+	err = s.persistLeaderboardExpirationTime(ctx, leaderboard)
+	if err != nil {
+		return nil, NewGeneralError(setMemberScoreServiceLabel, err.Error())
+	}
+
+	if scoreTTL != "" {
+		err = s.persistMembersTTL(ctx, leaderboard, members, scoreTTL)
+		if err != nil {
+			return nil, NewGeneralError(setMemberScoreServiceLabel, err.Error())
+		}
+	}
+
+	return members[0], nil
+}

--- a/leaderboard/service/set_members_score.go
+++ b/leaderboard/service/set_members_score.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/topfreegames/podium/leaderboard/database"
+	"github.com/topfreegames/podium/leaderboard/expiration"
+	"github.com/topfreegames/podium/leaderboard/model"
+)
+
+const setMembersScoreServiceLabel = "set members score"
+
+// SetMembersScore return member informations that is
+func (s *Service) SetMembersScore(ctx context.Context, leaderboard string, members []*model.Member, prevRank bool, scoreTTL string) error {
+	err := s.setLeaderboardExpirationTime(ctx, leaderboard)
+	if err != nil {
+		return err
+	}
+
+	if prevRank {
+		err := s.setMembersPreviousRank(ctx, leaderboard, members, "desc")
+		if err != nil {
+			return err
+		}
+	}
+
+	err = s.setMembers(ctx, leaderboard, members)
+	if err != nil {
+		return err
+	}
+
+	if scoreTTL != "" {
+		err = s.setMembersTTL(ctx, leaderboard, members, scoreTTL)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) setLeaderboardExpirationTime(ctx context.Context, leaderboard string) error {
+	expireAt, err := expiration.GetExpireAt(leaderboard)
+	if err != nil {
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
+	}
+
+	_, err = s.Database.GetLeaderboardExpiration(ctx, leaderboard)
+	if err != nil {
+		if _, ok := err.(*database.TTLNotFoundError); ok {
+			err = s.Database.SetLeaderboardExpiration(ctx, leaderboard, time.Unix(expireAt, 0))
+			if err != nil {
+				return NewGeneralError(setMembersScoreServiceLabel, err.Error())
+			}
+
+		} else {
+			return NewGeneralError(setMembersScoreServiceLabel, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) setMembersPreviousRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
+	memberIDs := make([]string, 0, len(members))
+	for _, member := range members {
+		memberIDs = append(memberIDs, member.PublicID)
+	}
+
+	databaseMembers, err := s.Database.GetMembers(ctx, leaderboard, order, true, memberIDs...)
+	if err != nil {
+		return NewGeneralError(getMembersServiceLabel, err.Error())
+	}
+
+	for i, member := range members {
+		if databaseMembers[i] != nil {
+			member.PreviousRank = int(databaseMembers[i].Rank)
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) setMembers(ctx context.Context, leaderboard string, members []*model.Member) error {
+	databaseMembers := make([]*database.Member, 0, len(members))
+	for _, member := range members {
+		databaseMembers = append(databaseMembers, &database.Member{
+			Member: member.PublicID,
+			Score:  float64(member.Score),
+		})
+	}
+
+	err := s.Database.SetMembers(ctx, leaderboard, databaseMembers)
+	if err != nil {
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
+	}
+
+	return nil
+}
+
+func (s *Service) setMembersTTL(ctx context.Context, leaderboard string, members []*model.Member, scoreTTL string) error {
+	ttl, err := strconv.ParseInt(scoreTTL, 10, 64)
+	if err != nil {
+		return NewGeneralError(getMembersServiceLabel, err.Error())
+	}
+
+	timeToExpire := time.Now().UTC().Add(time.Duration(ttl) * time.Second)
+
+	databaseMembers := make([]*database.Member, 0, len(members))
+	for _, member := range members {
+		databaseMembers = append(databaseMembers, &database.Member{
+			Member: member.PublicID,
+			TTL:    timeToExpire,
+		})
+		member.ExpireAt = int(timeToExpire.Unix())
+	}
+
+	err = s.Database.SetMembersTTL(ctx, leaderboard, databaseMembers)
+	if err != nil {
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
+	}
+
+	return nil
+
+}

--- a/leaderboard/service/set_members_score.go
+++ b/leaderboard/service/set_members_score.go
@@ -12,27 +12,34 @@ import (
 
 const setMembersScoreServiceLabel = "set members score"
 
+const setMembersOrder = "desc"
+
 // SetMembersScore return member informations that is
 func (s *Service) SetMembersScore(ctx context.Context, leaderboard string, members []*model.Member, prevRank bool, scoreTTL string) error {
-	err := s.setLeaderboardExpirationTime(ctx, leaderboard)
-	if err != nil {
-		return err
-	}
-
 	if prevRank {
-		err := s.setMembersPreviousRank(ctx, leaderboard, members, "desc")
+		err := s.setMembersPreviousRank(ctx, leaderboard, members, setMembersOrder)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = s.setMembers(ctx, leaderboard, members)
+	err := s.persistMembers(ctx, leaderboard, members)
+	if err != nil {
+		return err
+	}
+
+	err = s.setMembersRank(ctx, leaderboard, members, setMembersOrder)
+	if err != nil {
+		return err
+	}
+
+	err = s.persistLeaderboardExpirationTime(ctx, leaderboard)
 	if err != nil {
 		return err
 	}
 
 	if scoreTTL != "" {
-		err = s.setMembersTTL(ctx, leaderboard, members, scoreTTL)
+		err = s.persistMembersTTL(ctx, leaderboard, members, scoreTTL)
 		if err != nil {
 			return err
 		}
@@ -41,7 +48,66 @@ func (s *Service) SetMembersScore(ctx context.Context, leaderboard string, membe
 	return nil
 }
 
-func (s *Service) setLeaderboardExpirationTime(ctx context.Context, leaderboard string) error {
+func (s *Service) setMembersPreviousRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
+	databaseMembers, err := s.getDatabaseMembers(ctx, leaderboard, members, order)
+	if err != nil {
+		return err
+	}
+
+	for i, member := range members {
+		if databaseMembers[i] != nil {
+			member.PreviousRank = int(databaseMembers[i].Rank + 1)
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) persistMembers(ctx context.Context, leaderboard string, members []*model.Member) error {
+	databaseMembers := make([]*database.Member, 0, len(members))
+	for _, member := range members {
+		databaseMembers = append(databaseMembers, &database.Member{
+			Member: member.PublicID,
+			Score:  float64(member.Score),
+		})
+	}
+
+	err := s.Database.SetMembers(ctx, leaderboard, databaseMembers)
+	if err != nil {
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
+	}
+
+	return nil
+}
+
+func (s *Service) setMembersRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
+	databaseMembers, err := s.getDatabaseMembers(ctx, leaderboard, members, order)
+	if err != nil {
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
+	}
+
+	for i, member := range databaseMembers {
+		members[i].Rank = int(member.Rank + 1)
+	}
+
+	return nil
+}
+
+func (s *Service) getDatabaseMembers(ctx context.Context, leaderboard string, members []*model.Member, order string) ([]*database.Member, error) {
+	memberIDs := make([]string, 0, len(members))
+	for _, member := range members {
+		memberIDs = append(memberIDs, member.PublicID)
+	}
+
+	databaseMembers, err := s.Database.GetMembers(ctx, leaderboard, order, true, memberIDs...)
+	if err != nil {
+		return nil, NewGeneralError(setMembersScoreServiceLabel, err.Error())
+	}
+
+	return databaseMembers, nil
+}
+
+func (s *Service) persistLeaderboardExpirationTime(ctx context.Context, leaderboard string) error {
 	expireAt, err := expiration.GetExpireAt(leaderboard)
 	if err != nil {
 		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
@@ -63,47 +129,10 @@ func (s *Service) setLeaderboardExpirationTime(ctx context.Context, leaderboard 
 	return nil
 }
 
-func (s *Service) setMembersPreviousRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
-	memberIDs := make([]string, 0, len(members))
-	for _, member := range members {
-		memberIDs = append(memberIDs, member.PublicID)
-	}
-
-	databaseMembers, err := s.Database.GetMembers(ctx, leaderboard, order, true, memberIDs...)
-	if err != nil {
-		return NewGeneralError(getMembersServiceLabel, err.Error())
-	}
-
-	for i, member := range members {
-		if databaseMembers[i] != nil {
-			member.PreviousRank = int(databaseMembers[i].Rank)
-		}
-	}
-
-	return nil
-}
-
-func (s *Service) setMembers(ctx context.Context, leaderboard string, members []*model.Member) error {
-	databaseMembers := make([]*database.Member, 0, len(members))
-	for _, member := range members {
-		databaseMembers = append(databaseMembers, &database.Member{
-			Member: member.PublicID,
-			Score:  float64(member.Score),
-		})
-	}
-
-	err := s.Database.SetMembers(ctx, leaderboard, databaseMembers)
-	if err != nil {
-		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
-	}
-
-	return nil
-}
-
-func (s *Service) setMembersTTL(ctx context.Context, leaderboard string, members []*model.Member, scoreTTL string) error {
+func (s *Service) persistMembersTTL(ctx context.Context, leaderboard string, members []*model.Member, scoreTTL string) error {
 	ttl, err := strconv.ParseInt(scoreTTL, 10, 64)
 	if err != nil {
-		return NewGeneralError(getMembersServiceLabel, err.Error())
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
 	}
 
 	timeToExpire := time.Now().UTC().Add(time.Duration(ttl) * time.Second)

--- a/leaderboard/service/set_members_score.go
+++ b/leaderboard/service/set_members_score.go
@@ -2,11 +2,7 @@ package service
 
 import (
 	"context"
-	"strconv"
-	"time"
 
-	"github.com/topfreegames/podium/leaderboard/database"
-	"github.com/topfreegames/podium/leaderboard/expiration"
 	"github.com/topfreegames/podium/leaderboard/model"
 )
 
@@ -19,138 +15,31 @@ func (s *Service) SetMembersScore(ctx context.Context, leaderboard string, membe
 	if prevRank {
 		err := s.setMembersPreviousRank(ctx, leaderboard, members, setMembersOrder)
 		if err != nil {
-			return err
+			return NewGeneralError(setMembersScoreServiceLabel, err.Error())
 		}
 	}
 
 	err := s.persistMembers(ctx, leaderboard, members)
 	if err != nil {
-		return err
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
 	}
 
 	err = s.setMembersRank(ctx, leaderboard, members, setMembersOrder)
 	if err != nil {
-		return err
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
 	}
 
 	err = s.persistLeaderboardExpirationTime(ctx, leaderboard)
 	if err != nil {
-		return err
+		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
 	}
 
 	if scoreTTL != "" {
 		err = s.persistMembersTTL(ctx, leaderboard, members, scoreTTL)
 		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (s *Service) setMembersPreviousRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
-	databaseMembers, err := s.getDatabaseMembers(ctx, leaderboard, members, order)
-	if err != nil {
-		return err
-	}
-
-	for i, member := range members {
-		if databaseMembers[i] != nil {
-			member.PreviousRank = int(databaseMembers[i].Rank + 1)
-		}
-	}
-
-	return nil
-}
-
-func (s *Service) persistMembers(ctx context.Context, leaderboard string, members []*model.Member) error {
-	databaseMembers := make([]*database.Member, 0, len(members))
-	for _, member := range members {
-		databaseMembers = append(databaseMembers, &database.Member{
-			Member: member.PublicID,
-			Score:  float64(member.Score),
-		})
-	}
-
-	err := s.Database.SetMembers(ctx, leaderboard, databaseMembers)
-	if err != nil {
-		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
-	}
-
-	return nil
-}
-
-func (s *Service) setMembersRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
-	databaseMembers, err := s.getDatabaseMembers(ctx, leaderboard, members, order)
-	if err != nil {
-		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
-	}
-
-	for i, member := range databaseMembers {
-		members[i].Rank = int(member.Rank + 1)
-	}
-
-	return nil
-}
-
-func (s *Service) getDatabaseMembers(ctx context.Context, leaderboard string, members []*model.Member, order string) ([]*database.Member, error) {
-	memberIDs := make([]string, 0, len(members))
-	for _, member := range members {
-		memberIDs = append(memberIDs, member.PublicID)
-	}
-
-	databaseMembers, err := s.Database.GetMembers(ctx, leaderboard, order, true, memberIDs...)
-	if err != nil {
-		return nil, NewGeneralError(setMembersScoreServiceLabel, err.Error())
-	}
-
-	return databaseMembers, nil
-}
-
-func (s *Service) persistLeaderboardExpirationTime(ctx context.Context, leaderboard string) error {
-	expireAt, err := expiration.GetExpireAt(leaderboard)
-	if err != nil {
-		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
-	}
-
-	_, err = s.Database.GetLeaderboardExpiration(ctx, leaderboard)
-	if err != nil {
-		if _, ok := err.(*database.TTLNotFoundError); ok {
-			err = s.Database.SetLeaderboardExpiration(ctx, leaderboard, time.Unix(expireAt, 0))
-			if err != nil {
-				return NewGeneralError(setMembersScoreServiceLabel, err.Error())
-			}
-
-		} else {
 			return NewGeneralError(setMembersScoreServiceLabel, err.Error())
 		}
 	}
 
 	return nil
-}
-
-func (s *Service) persistMembersTTL(ctx context.Context, leaderboard string, members []*model.Member, scoreTTL string) error {
-	ttl, err := strconv.ParseInt(scoreTTL, 10, 64)
-	if err != nil {
-		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
-	}
-
-	timeToExpire := time.Now().UTC().Add(time.Duration(ttl) * time.Second)
-
-	databaseMembers := make([]*database.Member, 0, len(members))
-	for _, member := range members {
-		databaseMembers = append(databaseMembers, &database.Member{
-			Member: member.PublicID,
-			TTL:    timeToExpire,
-		})
-		member.ExpireAt = int(timeToExpire.Unix())
-	}
-
-	err = s.Database.SetMembersTTL(ctx, leaderboard, databaseMembers)
-	if err != nil {
-		return NewGeneralError(setMembersScoreServiceLabel, err.Error())
-	}
-
-	return nil
-
 }

--- a/leaderboard/service/set_members_score_test.go
+++ b/leaderboard/service/set_members_score_test.go
@@ -1,0 +1,460 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/topfreegames/podium/leaderboard/database"
+	"github.com/topfreegames/podium/leaderboard/expiration"
+	"github.com/topfreegames/podium/leaderboard/model"
+	"github.com/topfreegames/podium/leaderboard/service"
+)
+
+var _ = Describe("Service SetMembersScore", func() {
+	var ctrl *gomock.Controller
+	var mock *database.MockDatabase
+	var svc *service.Service
+
+	var leaderboard string = "leaderboard"
+	var previousRank bool = false
+	var scoreTTL string = ""
+
+	databaseMembersToInsert := []*database.Member{
+		{
+			Member: "member1",
+			Score:  1.0,
+		},
+		{
+			Member: "member2",
+			Score:  2.0,
+		},
+	}
+
+	databaseMembersToGetRank := []string{
+		"member1",
+		"member2",
+	}
+
+	databaseMembersPreviousRankReturned := []*database.Member{
+		{
+			Member: "member1",
+			Score:  2.0,
+			Rank:   int64(0),
+		},
+		{
+			Member: "member2",
+			Score:  1.0,
+			Rank:   int64(1),
+		},
+	}
+
+	databaseMembersReturned := []*database.Member{
+		{
+			Member: "member1",
+			Score:  1.0,
+			Rank:   int64(1),
+		},
+		{
+			Member: "member2",
+			Score:  2.0,
+			Rank:   int64(0),
+		},
+	}
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mock = database.NewMockDatabase(ctrl)
+
+		svc = &service.Service{mock}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("When previousRank is false", func() {
+		It("Should set Members with previousRank equals zero", func() {
+			members := []*model.Member{
+				{
+					PublicID: "member1",
+					Score:    1,
+				},
+				{
+					PublicID: "member2",
+					Score:    2,
+				},
+			}
+
+			expectedMembers := []*model.Member{
+				{
+					PublicID:     "member1",
+					Score:        1,
+					PreviousRank: 0,
+					Rank:         2,
+				},
+				{
+					PublicID:     "member2",
+					Score:        2,
+					PreviousRank: 0,
+					Rank:         1,
+				},
+			}
+
+			mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Times(1).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+				gomock.Eq(databaseMembersToGetRank[1]),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(members).To(Equal(expectedMembers))
+		})
+	})
+
+	Describe("When previousRank is true", func() {
+		previousRank := true
+
+		It("Should set Members with previousRank", func() {
+			members := []*model.Member{
+				{
+					PublicID: "member1",
+					Score:    1,
+				},
+				{
+					PublicID: "member2",
+					Score:    2,
+				},
+			}
+
+			expectedMembers := []*model.Member{
+				{
+					PublicID:     "member1",
+					Score:        1,
+					PreviousRank: 1,
+					Rank:         2,
+				},
+				{
+					PublicID:     "member2",
+					Score:        2,
+					PreviousRank: 2,
+					Rank:         1,
+				},
+			}
+
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+				gomock.Eq(databaseMembersToGetRank[1]),
+			).Times(1).Return(databaseMembersPreviousRankReturned, nil)
+
+			mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+				gomock.Eq(databaseMembersToGetRank[1]),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(members).To(Equal(expectedMembers))
+		})
+
+		It("Should return error if GetMembers return in error", func() {
+			members := []*model.Member{
+				{
+					PublicID: "member1",
+					Score:    1,
+				},
+				{
+					PublicID: "member2",
+					Score:    2,
+				},
+			}
+
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+				gomock.Eq(databaseMembersToGetRank[1]),
+			).Times(1).Return(nil, fmt.Errorf("New database error"))
+			err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+			Expect(err).To(Equal(service.NewGeneralError("set members score", "New database error")))
+		})
+	})
+
+	Describe("When scoreTTL is empty", func() {
+		It("Should SetMembers without filling expire ordered set", func() {
+			members := []*model.Member{
+				{
+					PublicID: "member1",
+					Score:    1,
+				},
+				{
+					PublicID: "member2",
+					Score:    2,
+				},
+			}
+
+			expectedMembers := []*model.Member{
+				{
+					PublicID:     "member1",
+					Score:        1,
+					PreviousRank: 0,
+					Rank:         2,
+				},
+				{
+					PublicID:     "member2",
+					Score:        2,
+					PreviousRank: 0,
+					Rank:         1,
+				},
+			}
+
+			mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+				gomock.Eq(databaseMembersToGetRank[1]),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(members).To(Equal(expectedMembers))
+		})
+	})
+
+	Describe("When scoreTTL is set", func() {
+		scoreTTL := "100"
+
+		It("Should SetMembers filling expire ordered set", func() {
+			members := []*model.Member{
+				{
+					PublicID: "member1",
+					Score:    1,
+				},
+				{
+					PublicID: "member2",
+					Score:    2,
+				},
+			}
+
+			mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+				gomock.Eq(databaseMembersToGetRank[1]),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			mock.EXPECT().SetMembersTTL(gomock.Any(), gomock.Eq(leaderboard), gomock.Any()).Times(1).Return(nil)
+
+			err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(members[0].ExpireAt).To(BeNumerically("~", time.Now().Add(100*time.Second).Unix(), 100))
+			Expect(members[1].ExpireAt).To(BeNumerically("~", time.Now().Add(100*time.Second).Unix(), 100))
+		})
+	})
+
+	Describe("When scoreTTL is invalid", func() {
+		scoreTTL := "invalid"
+
+		It("Should return error", func() {
+			members := []*model.Member{
+				{
+					PublicID: "member1",
+					Score:    1,
+				},
+				{
+					PublicID: "member2",
+					Score:    2,
+				},
+			}
+
+			mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+				gomock.Eq(databaseMembersToGetRank[1]),
+			).Return(databaseMembersReturned, nil)
+			mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboard)).Return(int64(1234), nil)
+
+			err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+			Expect(err).To(MatchError(service.NewGeneralError("set members score", "strconv.ParseInt: parsing \"invalid\": invalid syntax")))
+
+		})
+	})
+
+	It("Should return error if database SetMembers return in error", func() {
+		members := []*model.Member{
+			{
+				PublicID: "member1",
+				Score:    1,
+			},
+			{
+				PublicID: "member2",
+				Score:    2,
+			},
+		}
+
+		mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Return(fmt.Errorf("New database error"))
+
+		err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+		Expect(err).To(MatchError(service.NewGeneralError("set members score", "New database error")))
+	})
+
+	It("Should return error if database GetMembers return in error", func() {
+		members := []*model.Member{
+			{
+				PublicID: "member1",
+				Score:    1,
+			},
+			{
+				PublicID: "member2",
+				Score:    2,
+			},
+		}
+
+		mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboard),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(databaseMembersToGetRank[0]),
+			gomock.Eq(databaseMembersToGetRank[1]),
+		).Return(nil, fmt.Errorf("New database error"))
+
+		err := svc.SetMembersScore(context.Background(), leaderboard, members, previousRank, scoreTTL)
+		Expect(err).NotTo(MatchError(service.NewGeneralError("set members score", "New database error")))
+
+	})
+
+	It("Should set leaderboard expiration if GetLeaderboardExpiration return TTLNotFoundError", func() {
+		leaderboardExpiration := fmt.Sprintf("year%d", time.Now().UTC().Year())
+		expireAt, err := expiration.GetExpireAt(leaderboardExpiration)
+		Expect(err).NotTo(HaveOccurred())
+
+		members := []*model.Member{
+			{
+				PublicID: "member1",
+				Score:    1,
+			},
+			{
+				PublicID: "member2",
+				Score:    2,
+			},
+		}
+
+		mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboardExpiration), gomock.Eq(databaseMembersToInsert)).Times(1).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboardExpiration),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(databaseMembersToGetRank[0]),
+			gomock.Eq(databaseMembersToGetRank[1]),
+		).Return(databaseMembersReturned, nil)
+		mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration)).Return(int64(-1), database.NewTTLNotFoundError(leaderboard))
+
+		mock.EXPECT().SetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration), time.Unix(expireAt, 0)).Return(nil)
+
+		err = svc.SetMembersScore(context.Background(), leaderboardExpiration, members, previousRank, scoreTTL)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should return error if database GetLeaderboardExpiration return in error", func() {
+		leaderboardExpiration := fmt.Sprintf("year%d", time.Now().UTC().Year())
+
+		members := []*model.Member{
+			{
+				PublicID: "member1",
+				Score:    1,
+			},
+			{
+				PublicID: "member2",
+				Score:    2,
+			},
+		}
+
+		mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboardExpiration), gomock.Eq(databaseMembersToInsert)).Times(1).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboardExpiration),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(databaseMembersToGetRank[0]),
+			gomock.Eq(databaseMembersToGetRank[1]),
+		).Return(databaseMembersReturned, nil)
+		mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration)).Return(int64(-1), fmt.Errorf("New database error"))
+
+		err := svc.SetMembersScore(context.Background(), leaderboardExpiration, members, previousRank, scoreTTL)
+		Expect(err).To(MatchError(service.NewGeneralError("set members score", "New database error")))
+	})
+
+	It("Should return error if database SetLeaderboardExpiration return in error", func() {
+		leaderboardExpiration := fmt.Sprintf("year%d", time.Now().UTC().Year())
+		expireAt, err := expiration.GetExpireAt(leaderboardExpiration)
+		Expect(err).NotTo(HaveOccurred())
+
+		members := []*model.Member{
+			{
+				PublicID: "member1",
+				Score:    1,
+			},
+			{
+				PublicID: "member2",
+				Score:    2,
+			},
+		}
+
+		mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboardExpiration), gomock.Eq(databaseMembersToInsert)).Times(1).Return(nil)
+		mock.EXPECT().GetMembers(
+			gomock.Any(),
+			gomock.Eq(leaderboardExpiration),
+			gomock.Eq("desc"),
+			gomock.Eq(true),
+			gomock.Eq(databaseMembersToGetRank[0]),
+			gomock.Eq(databaseMembersToGetRank[1]),
+		).Return(databaseMembersReturned, nil)
+		mock.EXPECT().GetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration)).Return(int64(-1), database.NewTTLNotFoundError(leaderboard))
+
+		mock.EXPECT().SetLeaderboardExpiration(gomock.Any(), gomock.Eq(leaderboardExpiration), time.Unix(expireAt, 0)).Return(fmt.Errorf("New database error"))
+
+		err = svc.SetMembersScore(context.Background(), leaderboardExpiration, members, previousRank, scoreTTL)
+		Expect(err).To(MatchError(service.NewGeneralError("set members score", "New database error")))
+	})
+
+})


### PR DESCRIPTION
WHY
=====

This PR proposes to add `SetMembersScore`, `SetMemberScore` and `IncrementMemberScore` service. Another thing is that the leaderboard had different types of time, so this PR proposes to standardize them.

WHAT WAS DONE
=====
* Standardize TTL type
* Add `SetMembersScore`
* Add `SetMemberScore`
* Add `IncrementMemberScore`