### PR TITLE
Create redis commands to be used by integration tests

### DIFF
--- a/leaderboard/database/redis.go
+++ b/leaderboard/database/redis.go
@@ -15,6 +15,7 @@ type Redis struct {
 
 var _ Database = &Redis{}
 
+// ExpirationSet is used to list expirations set that worker will use to remove members
 const ExpirationSet string = "expiration-sets"
 
 // RedisOptions is a struct to create a new redis client

--- a/leaderboard/database/redis/cluster_client.go
+++ b/leaderboard/database/redis/cluster_client.go
@@ -39,6 +39,19 @@ func (cc *clusterClient) Del(ctx context.Context, key string) error {
 	return nil
 }
 
+func (cc *clusterClient) Exists(ctx context.Context, key string) error {
+	value, err := cc.ClusterClient.Exists(ctx, key).Result()
+	if err != nil {
+		return NewGeneralError(err.Error())
+	}
+
+	if value != 1 {
+		return NewKeyNotFoundError(key)
+	}
+
+	return nil
+}
+
 // ExpireAt call redis EXPIREAT function
 func (cc *clusterClient) ExpireAt(ctx context.Context, key string, time time.Time) error {
 	result, err := cc.ClusterClient.ExpireAt(ctx, key, time).Result()
@@ -69,6 +82,15 @@ func (cc *clusterClient) SAdd(ctx context.Context, key, member string) error {
 		return NewGeneralError(err.Error())
 	}
 	return nil
+}
+
+// SMembers return all members in a set
+func (cc *clusterClient) SMembers(ctx context.Context, key string) ([]string, error) {
+	result, err := cc.ClusterClient.SMembers(ctx, key).Result()
+	if err != nil {
+		return nil, NewGeneralError(err.Error())
+	}
+	return result, nil
 }
 
 // SRem call redis SREM function

--- a/leaderboard/database/redis/cluster_client_test.go
+++ b/leaderboard/database/redis/cluster_client_test.go
@@ -59,6 +59,21 @@ var _ = Describe("Cluster Client", func() {
 		})
 	})
 
+	Describe("Exists", func() {
+		It("Should return nil if key exists", func() {
+			err := goRedis.Set(context.Background(), testKey, "testValue", 0).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = clusterClient.Exists(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should return KeyNotFoundError if key doesn't exists", func() {
+			err := clusterClient.Exists(context.Background(), testKey)
+			Expect(err).To(MatchError(redis.NewKeyNotFoundError(testKey)))
+		})
+	})
+
 	Describe("ExpireAt", func() {
 		It("Should return nil if timeout is set", func() {
 			expirationTime := time.Now().Add(10 * time.Minute)
@@ -104,6 +119,22 @@ var _ = Describe("Cluster Client", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(isMember).To(Equal(true))
+		})
+	})
+
+	Describe("SMembers", func() {
+		It("Should return all members in a set", func() {
+			member2 := "member2"
+			err := goRedis.SAdd(context.Background(), testKey, member).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = goRedis.SAdd(context.Background(), testKey, member2).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := clusterClient.SMembers(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(ContainElements(member, member2))
 		})
 	})
 

--- a/leaderboard/database/redis/errors.go
+++ b/leaderboard/database/redis/errors.go
@@ -15,7 +15,7 @@ func NewKeyNotFoundError(key string) *KeyNotFoundError {
 }
 
 func (knfe *KeyNotFoundError) Error() string {
-	return fmt.Sprintf("redis key %s not found", knfe.key)
+	return fmt.Sprintf("redis: key %s not found", knfe.key)
 }
 
 // TTLNotFoundError is an error throw when key has not TTL
@@ -31,7 +31,7 @@ func NewTTLNotFoundError(key string) *TTLNotFoundError {
 }
 
 func (knfe *TTLNotFoundError) Error() string {
-	return fmt.Sprintf("redis ttl to key %s not found", knfe.key)
+	return fmt.Sprintf("redis: ttl to key %s not found", knfe.key)
 }
 
 // MemberNotFoundError is an error throw when key has not Member
@@ -48,7 +48,7 @@ func NewMemberNotFoundError(key, member string) *MemberNotFoundError {
 }
 
 func (mnfe *MemberNotFoundError) Error() string {
-	return fmt.Sprintf("redis key %s not have member %s found", mnfe.key, mnfe.member)
+	return fmt.Sprintf("redis: key %s not have member %s found", mnfe.key, mnfe.member)
 }
 
 // GeneralError create a redis error that is not handled
@@ -57,7 +57,7 @@ type GeneralError struct {
 }
 
 func (ue *GeneralError) Error() string {
-	return fmt.Sprintf("redis error: %s", ue.msg)
+	return fmt.Sprintf("redis: error: %s", ue.msg)
 }
 
 // NewGeneralError create a new redis error that isnt handled

--- a/leaderboard/database/redis/mock.go
+++ b/leaderboard/database/redis/mock.go
@@ -49,6 +49,20 @@ func (mr *MockRedisMockRecorder) Del(ctx, key interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockRedis)(nil).Del), ctx, key)
 }
 
+// Exists mocks base method.
+func (m *MockRedis) Exists(ctx context.Context, key string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", ctx, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockRedisMockRecorder) Exists(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockRedis)(nil).Exists), ctx, key)
+}
+
 // ExpireAt mocks base method.
 func (m *MockRedis) ExpireAt(ctx context.Context, key string, time time.Time) error {
 	m.ctrl.T.Helper()
@@ -90,6 +104,21 @@ func (m *MockRedis) SAdd(ctx context.Context, key, member string) error {
 func (mr *MockRedisMockRecorder) SAdd(ctx, key, member interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SAdd", reflect.TypeOf((*MockRedis)(nil).SAdd), ctx, key, member)
+}
+
+// SMembers mocks base method.
+func (m *MockRedis) SMembers(ctx context.Context, key string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SMembers", ctx, key)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SMembers indicates an expected call of SMembers.
+func (mr *MockRedisMockRecorder) SMembers(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SMembers", reflect.TypeOf((*MockRedis)(nil).SMembers), ctx, key)
 }
 
 // SRem mocks base method.

--- a/leaderboard/database/redis/redis.go
+++ b/leaderboard/database/redis/redis.go
@@ -15,9 +15,11 @@ const (
 // Redis interface define wich redis methods will be used by leaderboard module
 type Redis interface {
 	Del(ctx context.Context, key string) error
+	Exists(ctx context.Context, key string) error
 	ExpireAt(ctx context.Context, key string, time time.Time) error
 	Ping(ctx context.Context) (string, error)
 	SAdd(ctx context.Context, key, member string) error
+	SMembers(ctx context.Context, key string) ([]string, error)
 	SRem(ctx context.Context, key, member string) error
 	TTL(ctx context.Context, key string) (time.Duration, error)
 	ZAdd(ctx context.Context, key string, members ...*Member) error

--- a/leaderboard/database/redis/standalone_client.go
+++ b/leaderboard/database/redis/standalone_client.go
@@ -43,6 +43,19 @@ func (c *standaloneClient) Del(ctx context.Context, key string) error {
 	return nil
 }
 
+// Exists return if a key exists on redis
+func (c *standaloneClient) Exists(ctx context.Context, key string) error {
+	value, err := c.Client.Exists(ctx, key).Result()
+	if err != nil {
+		return NewGeneralError(err.Error())
+	}
+	if value != 1 {
+		return NewKeyNotFoundError(key)
+	}
+
+	return nil
+}
+
 // ExpireAt call redis EXPIREAT function
 func (c *standaloneClient) ExpireAt(ctx context.Context, key string, time time.Time) error {
 	result, err := c.Client.ExpireAt(ctx, key, time).Result()
@@ -72,6 +85,15 @@ func (c *standaloneClient) SAdd(ctx context.Context, key, member string) error {
 		return NewGeneralError(err.Error())
 	}
 	return nil
+}
+
+// SMembers return all members in a set
+func (c *standaloneClient) SMembers(ctx context.Context, key string) ([]string, error) {
+	result, err := c.Client.SMembers(ctx, key).Result()
+	if err != nil {
+		return nil, NewGeneralError(err.Error())
+	}
+	return result, nil
 }
 
 // SRem call redis SREM function

--- a/leaderboard/database/redis/standalone_client_test.go
+++ b/leaderboard/database/redis/standalone_client_test.go
@@ -63,6 +63,21 @@ var _ = Describe("Standalone Client", func() {
 		})
 	})
 
+	Describe("Exists", func() {
+		It("Should return nil if key exists", func() {
+			err := goRedis.Set(context.Background(), testKey, "testValue", 0).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = standaloneClient.Exists(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should return KeyNotFoundError if key doesn't exists", func() {
+			err := standaloneClient.Exists(context.Background(), testKey)
+			Expect(err).To(MatchError(redis.NewKeyNotFoundError(testKey)))
+		})
+	})
+
 	Describe("ExpireAt", func() {
 		It("Should return nil if timeout is set", func() {
 			expirationTime := time.Now().Add(10 * time.Minute)
@@ -107,6 +122,22 @@ var _ = Describe("Standalone Client", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(isMember).To(Equal(true))
+		})
+	})
+
+	Describe("SMembers", func() {
+		It("Should return all members in a set", func() {
+			member2 := "member2"
+			err := goRedis.SAdd(context.Background(), testKey, member).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = goRedis.SAdd(context.Background(), testKey, member2).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := standaloneClient.SMembers(context.Background(), testKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(ContainElements(member, member2))
 		})
 	})
 


### PR DESCRIPTION
WHY
======

Leaderboard integration tests need some redis commands that was not previous developed as `SMembers` and `Exists`. This PR proposes to implement this commands.

WHAT WAS DONE
======
* Improve error messages
* Implement redis `SMembers`command
* Implement redis `Exists`command