### PR TITLE
Fix service file

### DIFF
--- a/leaderboard/service/interface.go
+++ b/leaderboard/service/interface.go
@@ -1,4 +1,4 @@
-package leaderboard
+package service
 
 import (
 	"context"

--- a/leaderboard/service/service.go
+++ b/leaderboard/service/service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/topfreegames/podium/leaderboard"
 	"github.com/topfreegames/podium/leaderboard/database"
 )
 
@@ -10,7 +9,7 @@ type Service struct {
 	database.Database
 }
 
-var _ leaderboard.Leaderboard = &Service{}
+var _ Leaderboard = &Service{}
 
 // NewService instantiate a new Service
 func NewService(database database.Database) *Service {


### PR DESCRIPTION
WHY
=====

The interface file standardize how leaderboard will work. This PR proposes to move it from leaderboard package to service that in a near future will avoid dependecy loop between service and leaderboard.

WHAT WAS DONE
=====
* Move interface file from `leaderboard` package to `service`