### PR TITLE
Apply integration tests changes to get_top_percentage service

### DIFF
--- a/leaderboard/service/errors.go
+++ b/leaderboard/service/errors.go
@@ -55,19 +55,3 @@ func NewPageOutOfRangeError(page, totalPage int) *PageOutOfRangeError {
 func (poor *PageOutOfRangeError) Error() string {
 	return fmt.Sprintf("page %d out of range (1, %d)", poor.page, poor.totalPage)
 }
-
-// InvalidOrderError is an error when an invalid order was gave
-type InvalidOrderError struct {
-	order string
-}
-
-func (ioe *InvalidOrderError) Error() string {
-	return fmt.Sprintf("invalid order: %s", ioe.order)
-}
-
-// NewInvalidOrderError create a new InvalidOrderError
-func NewInvalidOrderError(order string) *InvalidOrderError {
-	return &InvalidOrderError{
-		order: order,
-	}
-}

--- a/leaderboard/service/get_top_percentage.go
+++ b/leaderboard/service/get_top_percentage.go
@@ -16,7 +16,7 @@ func (s *Service) GetTopPercentage(ctx context.Context, leaderboardID string, pa
 	}
 
 	if order != "desc" && order != "asc" {
-		return nil, NewInvalidOrderError(order)
+		order = "desc"
 	}
 
 	amountInPercentage := float64(amount) / 100.0

--- a/leaderboard/service/get_top_percentage_test.go
+++ b/leaderboard/service/get_top_percentage_test.go
@@ -116,12 +116,16 @@ var _ = Describe("Service GetTopPercentage", func() {
 		})
 	})
 
-	It("Should return InvalidOrderError when order is invalid", func() {
+	It("Should use desc when order is invalid", func() {
 		order = "not_valid_order"
 
-		_, err := svc.GetTopPercentage(context.Background(), leaderboard, pageSize, amount, maxMembers, order)
-		Expect(err).Should(HaveOccurred())
-		Expect(err.Error()).To(Equal("invalid order: not_valid_order"))
+		mock.EXPECT().GetTotalMembers(gomock.Any(), gomock.Eq(leaderboard)).Return(100, nil)
+		mock.EXPECT().GetOrderedMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(0), gomock.Eq(2), gomock.Eq("desc")).Return(membersReturnedByDatabase, nil)
+
+		members, err := svc.GetTopPercentage(context.Background(), leaderboard, pageSize, amount, maxMembers, order)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(members).To(HaveLen(3))
+		Expect(members).To(Equal(expectedMembersToReturn))
 	})
 
 	It("Should return no members when percentage is small", func() {


### PR DESCRIPTION
WHY
=====
Integration test show some changes that should be done in leaderboard service. This PR proposes to change `GetTopPercentage` that should return descendent order if no order or invalid order is in parameter.

WHAT WAS DONE
=====
* Change `GetTopPercentage` service