### PR TITLE
Refactor GetAround functions to acord to integration tests

### DIFF
--- a/leaderboard/service/get_around_me_test.go
+++ b/leaderboard/service/get_around_me_test.go
@@ -38,8 +38,8 @@ var _ = Describe("Service GetAroundMe", func() {
 		var getLastIfNotFound = false
 		It("Should return members slice if all is OK", func() {
 			rank := 6
-			start := 5
-			stop := 7
+			start := 6
+			stop := 8
 
 			membersDatabaseReturn := []*database.Member{
 				&database.Member{
@@ -113,8 +113,8 @@ var _ = Describe("Service GetAroundMe", func() {
 
 		It("Should return error if GetOrderedMembers return in error", func() {
 			rank := 6
-			start := 5
-			stop := 7
+			start := 6
+			stop := 8
 
 			mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(rank, nil)
 			mock.EXPECT().GetTotalMembers(gomock.Any(), gomock.Eq(leaderboard)).Return(totalMembers, nil)
@@ -140,7 +140,7 @@ var _ = Describe("Service GetAroundMe", func() {
 
 		It("Should ask for last members if user is the last one", func() {
 			rank := 10
-			start := 8
+			start := 7
 			stop := 10
 
 			mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(rank, nil)
@@ -172,8 +172,8 @@ var _ = Describe("Service GetAroundMe", func() {
 		var getLastIfNotFound = true
 		It("Should return members slice if all is OK", func() {
 			rank := 6
-			start := 5
-			stop := 7
+			start := 6
+			stop := 8
 
 			membersDatabaseReturn := []*database.Member{
 				&database.Member{
@@ -222,7 +222,7 @@ var _ = Describe("Service GetAroundMe", func() {
 		})
 
 		It("Should return last members if getRank return member not found", func() {
-			start := 8
+			start := 7
 			stop := 10
 			membersDatabaseReturn := []*database.Member{
 				&database.Member{
@@ -287,7 +287,7 @@ var _ = Describe("Service GetAroundMe", func() {
 		})
 
 		It("Should return error if GetOrderedMembers return in error", func() {
-			start := 8
+			start := 7
 			stop := 10
 
 			mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(-1, database.NewMemberNotFoundError(leaderboard, member))

--- a/leaderboard/service/get_around_score.go
+++ b/leaderboard/service/get_around_score.go
@@ -2,9 +2,8 @@ package service
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 
-	"github.com/topfreegames/podium/leaderboard/database"
 	"github.com/topfreegames/podium/leaderboard/model"
 )
 
@@ -21,12 +20,8 @@ func (s *Service) GetAroundScore(ctx context.Context, leaderboard string, pageSi
 		return nil, err
 	}
 
-	memberRank, err := s.fetchMemberRank(ctx, leaderboard, member, order, false)
+	memberRank, err := s.fetchMemberRank(ctx, leaderboard, member, order, true)
 	if err != nil {
-		if _, ok := err.(*database.MemberNotFoundError); ok {
-			return nil, NewMemberNotFoundError(leaderboard, member)
-		}
-
 		return nil, NewGeneralError(getAroundScoreServiceLabel, err.Error())
 	}
 
@@ -46,12 +41,12 @@ func (s *Service) GetAroundScore(ctx context.Context, leaderboard string, pageSi
 }
 
 func (s *Service) getMemberIDWithClosestScore(ctx context.Context, leaderboard string, score int64) (string, error) {
-	memberSlice, err := s.Database.GetMemberIDsWithScoreInsideRange(ctx, leaderboard, "-inf", fmt.Sprint(score), 0, 1)
+	memberSlice, err := s.Database.GetMemberIDsWithScoreInsideRange(ctx, leaderboard, "-inf", strconv.FormatInt(score, 10), 0, 1)
 	if err != nil {
 		return "", NewGeneralError(getAroundScoreServiceLabel, err.Error())
 	}
 	if len(memberSlice) == 0 {
-		return "", NewMemberNotFoundError(leaderboard, fmt.Sprint(score))
+		return "", nil
 	}
 
 	return memberSlice[0], nil

--- a/leaderboard/service/get_members_test.go
+++ b/leaderboard/service/get_members_test.go
@@ -36,34 +36,85 @@ var _ = Describe("Service GetMembers", func() {
 
 	It("Should return members slice if all is OK", func() {
 		membersDatabaseReturn := []*database.Member{
-			&database.Member{
+			{
 				Member: "member1",
 				Score:  float64(1),
 				Rank:   int64(0),
 				TTL:    time.Unix(10000, 0),
 			},
 			nil,
-			&database.Member{
+			{
 				Member: "member3",
 				Score:  float64(3),
 				Rank:   int64(1),
-				TTL:    time.Unix(10001, 0),
+				TTL:    time.Time{},
 			},
 		}
 
 		membersReturn := []*model.Member{
-			&model.Member{
+			{
 				PublicID: "member1",
 				Score:    1,
-				Rank:     0 + 0 + 1,
+				Rank:     1,
 				ExpireAt: 10000,
 			},
-			nil,
-			&model.Member{
+			{
 				PublicID: "member3",
 				Score:    3,
-				Rank:     0 + 1 + 1,
-				ExpireAt: 10001,
+				Rank:     2,
+				ExpireAt: 0,
+			},
+		}
+
+		mock.EXPECT().GetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(order), gomock.Eq(includeTTL), gomock.Eq("member1"), gomock.Eq("member2"), gomock.Eq("member3")).Return(membersDatabaseReturn, nil)
+
+		membersFromService, err := svc.GetMembers(context.Background(), leaderboard, members, order, includeTTL)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(membersFromService).To(Equal(membersReturn))
+	})
+
+	It("Should order members", func() {
+		membersDatabaseReturn := []*database.Member{
+			{
+				Member: "member1",
+				Score:  float64(1),
+				Rank:   int64(0),
+				TTL:    time.Unix(10000, 0),
+			},
+			{
+				Member: "member3",
+				Score:  float64(3),
+				Rank:   int64(2),
+				TTL:    time.Unix(10000, 0),
+			},
+			nil,
+			{
+				Member: "member2",
+				Score:  float64(2),
+				Rank:   int64(1),
+				TTL:    time.Time{},
+			},
+		}
+
+		membersReturn := []*model.Member{
+			{
+				PublicID: "member1",
+				Score:    1,
+				Rank:     1,
+				ExpireAt: 10000,
+			},
+			{
+				PublicID: "member2",
+				Score:    2,
+				Rank:     2,
+				ExpireAt: 0,
+			},
+			{
+				PublicID: "member3",
+				Score:    3,
+				Rank:     3,
+				ExpireAt: 10000,
 			},
 		}
 

--- a/leaderboard/service/indexes.go
+++ b/leaderboard/service/indexes.go
@@ -26,11 +26,10 @@ func (s *Service) calculateIndexesAroundMemberRank(ctx context.Context, leaderbo
 	if start < 0 {
 		start = 0
 	}
-
-	stop := start + pageSize - 1
+	stop := (start + pageSize) - 1
 	if stop > totalMembers {
 		stop = totalMembers
-		start = stop - pageSize + 1
+		start = stop - pageSize
 		if start < 0 {
 			start = 0
 		}

--- a/leaderboard/service/members.go
+++ b/leaderboard/service/members.go
@@ -44,7 +44,7 @@ func (s *Service) fetchMemberRank(ctx context.Context, leaderboard, member, orde
 		}
 	}
 
-	return memberRank, nil
+	return memberRank + 1, nil
 }
 
 func (s *Service) setMembersPreviousRank(ctx context.Context, leaderboard string, members []*model.Member, order string) error {
@@ -56,7 +56,10 @@ func (s *Service) setMembersPreviousRank(ctx context.Context, leaderboard string
 	for i, member := range members {
 		if databaseMembers[i] != nil {
 			member.PreviousRank = int(databaseMembers[i].Rank + 1)
+			continue
 		}
+
+		member.PreviousRank = -1
 	}
 
 	return nil

--- a/leaderboard/service/set_member_score_test.go
+++ b/leaderboard/service/set_member_score_test.go
@@ -122,6 +122,38 @@ var _ = Describe("Service SetMemberScore", func() {
 			Expect(member).To(Equal(expectedMember))
 		})
 
+		It("Should set a non existent member as rank equals to -1", func() {
+			databaseMembersPreviousRankReturned := []*database.Member{nil}
+			expectedMember := &model.Member{
+				PublicID:     "member1",
+				Score:        1,
+				PreviousRank: -1,
+				Rank:         2,
+			}
+
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+			).Times(1).Return(databaseMembersPreviousRankReturned, nil)
+
+			mock.EXPECT().SetMembers(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(databaseMembersToInsert)).Return(nil)
+			mock.EXPECT().GetMembers(
+				gomock.Any(),
+				gomock.Eq(leaderboard),
+				gomock.Eq("desc"),
+				gomock.Eq(true),
+				gomock.Eq(databaseMembersToGetRank[0]),
+			).Return(databaseMembersReturned, nil)
+
+			member, err := svc.SetMemberScore(context.Background(), leaderboard, member, score, previousRank, scoreTTL)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(member).To(Equal(expectedMember))
+		})
+
 		It("Should return error if GetMembers return in error", func() {
 			mock.EXPECT().GetMembers(
 				gomock.Any(),


### PR DESCRIPTION
WHY
=======
This PR proposes to attack two points.
The first is the previous index calculation on GetAround routes was done moving the center of the range one down, so the index in the service is calculated with error.
The second is fix the time calculation
The third is that when argument `previousRank` is set as `false` the value should be return as `-1`.

WHAT WAS DONE
=======
* Change index calculation
* Fix time calculation
* Set `PreviousRank` as `-1` as when parameter `previousRank` on `GetAround` functions