### PR TITLE
Fix index calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,11 @@ deployments/docker-compose.yaml: deployments/docker-compose-model.yaml
 compose-up-dependencies: deployments/docker-compose.yaml ## Run all dependencies using docker-compose
 	@docker-compose -f $< up -d redis-node-0 redis-node-1 redis-node-2 redis-standalone initialize-cluster
 
+compose-up-api: deployments/docker-compose.yaml ## Initialize api on composer environment
+	@docker-compose -f $< up -d --build podium-api podium-api
+
 compose-test: deployments/docker-compose.yaml compose-up-dependencies ## Execute podium tests using docker-compose
-	@docker-compose -f $< up --build podium-test
+	@docker-compose -f $< up podium-test
 
 compose-down: deployments/docker-compose.yaml ## Stop all dependency containers
 	@docker-compose -f $< down

--- a/leaderboard/integration_test.go
+++ b/leaderboard/integration_test.go
@@ -395,6 +395,22 @@ var _ = Describe("Leaderboard integration tests", func() {
 			Expect(lastAroundMe.PublicID).To(Equal("member_7"))
 		})
 
+		It("should always return page size members when page size is less than total members", func() {
+			pageSize := 3
+			for i := 0; i < 5; i++ {
+				_, err := leaderboards.SetMemberScore(NewEmptyCtx(), testLeaderboardID, "member_"+strconv.Itoa(i), int64(i), false, "")
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			for i := 0; i < 5; i++ {
+				members, err := leaderboards.GetAroundMe(NewEmptyCtx(), testLeaderboardID, pageSize, fmt.Sprintf("member_%d", i), "desc", false)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(members)).To(Equal(pageSize))
+			}
+
+		})
+
 		It("should get members around specific member in reverse order", func() {
 			pageSize := 20
 			for i := 0; i < 101; i++ {
@@ -490,6 +506,22 @@ var _ = Describe("Leaderboard integration tests", func() {
 			Expect(len(members)).To(Equal(pageSize))
 			Expect(firstAroundMe.PublicID).To(Equal("member_31"))
 			Expect(lastAroundMe.PublicID).To(Equal("member_7"))
+		})
+
+		It("should always return page size members when page size is less than total members", func() {
+			pageSize := 3
+			for i := 0; i < 5; i++ {
+				_, err := leaderboards.SetMemberScore(NewEmptyCtx(), testLeaderboardID, "member_"+strconv.Itoa(i), int64(i), false, "")
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			for i := 0; i < 5; i++ {
+				members, err := leaderboards.GetAroundScore(NewEmptyCtx(), testLeaderboardID, pageSize, int64(i), "desc")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(members)).To(Equal(pageSize))
+			}
+
 		})
 
 		It("should get members around specific score reverse order", func() {

--- a/leaderboard/service/get_around_me_test.go
+++ b/leaderboard/service/get_around_me_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Service GetAroundMe", func() {
 		It("Should ask for last members if user is the last one", func() {
 			rank := 10
 			start := 7
-			stop := 10
+			stop := 9
 
 			mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(rank, nil)
 			mock.EXPECT().GetTotalMembers(gomock.Any(), gomock.Eq(leaderboard)).Return(totalMembers, nil)
@@ -156,7 +156,7 @@ var _ = Describe("Service GetAroundMe", func() {
 			var rank int = 0
 			var totalMembers int = 2
 			start := 0
-			stop := 2
+			stop := 1
 
 			mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(rank, nil)
 			mock.EXPECT().GetTotalMembers(gomock.Any(), gomock.Eq(leaderboard)).Return(totalMembers, nil)
@@ -223,7 +223,7 @@ var _ = Describe("Service GetAroundMe", func() {
 
 		It("Should return last members if getRank return member not found", func() {
 			start := 7
-			stop := 10
+			stop := 9
 			membersDatabaseReturn := []*database.Member{
 				&database.Member{
 					Member: "member1",
@@ -288,7 +288,7 @@ var _ = Describe("Service GetAroundMe", func() {
 
 		It("Should return error if GetOrderedMembers return in error", func() {
 			start := 7
-			stop := 10
+			stop := 9
 
 			mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(-1, database.NewMemberNotFoundError(leaderboard, member))
 			mock.EXPECT().GetTotalMembers(gomock.Any(), gomock.Eq(leaderboard)).Return(totalMembers, nil)
@@ -302,7 +302,7 @@ var _ = Describe("Service GetAroundMe", func() {
 		It("Should ask for all members if totalMembers is less than pageSize", func() {
 			var totalMembers int = 2
 			start := 0
-			stop := 2
+			stop := 1
 
 			mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(-1, database.NewMemberNotFoundError(leaderboard, member))
 			mock.EXPECT().GetTotalMembers(gomock.Any(), gomock.Eq(leaderboard)).Return(totalMembers, nil)

--- a/leaderboard/service/get_around_score_test.go
+++ b/leaderboard/service/get_around_score_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Service GetAroundScore", func() {
 
 	It("Should return member slice with last members if GetMemberIDsWithScoreInsideRange return no member", func() {
 		start := 7
-		stop := 10
+		stop := 9
 
 		membersDatabaseReturn := []*database.Member{
 			{
@@ -196,7 +196,7 @@ var _ = Describe("Service GetAroundScore", func() {
 	It("Should ask for last members if user is the last one", func() {
 		rank := 10
 		start := 7
-		stop := 10
+		stop := 9
 
 		mock.EXPECT().GetMemberIDsWithScoreInsideRange(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq("-inf"), gomock.Eq(fmt.Sprint(score)), gomock.Eq(0), gomock.Eq(1)).Return([]string{member}, nil)
 
@@ -213,7 +213,7 @@ var _ = Describe("Service GetAroundScore", func() {
 		var rank int = 0
 		var totalMembers int = 2
 		start := 0
-		stop := 2
+		stop := 1
 
 		mock.EXPECT().GetMemberIDsWithScoreInsideRange(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq("-inf"), gomock.Eq(fmt.Sprint(score)), gomock.Eq(0), gomock.Eq(1)).Return([]string{member}, nil)
 		mock.EXPECT().GetRank(gomock.Any(), gomock.Eq(leaderboard), gomock.Eq(member), gomock.Eq(order)).Return(rank, nil)

--- a/leaderboard/service/indexes.go
+++ b/leaderboard/service/indexes.go
@@ -27,9 +27,9 @@ func (s *Service) calculateIndexesAroundMemberRank(ctx context.Context, leaderbo
 		start = 0
 	}
 	stop := (start + pageSize) - 1
-	if stop > totalMembers {
-		stop = totalMembers
-		start = stop - pageSize
+	if stop >= totalMembers {
+		stop = totalMembers - 1
+		start = stop - pageSize + 1
 		if start < 0 {
 			start = 0
 		}


### PR DESCRIPTION
WHY
========

The changes introduce a problem on `GetAroundMe` and `GetAroundScore`, that return less elements than `pageSize` argument. This PR proposes to fix this problem.

WHAT WAS DONE
========
* Add `compose-up-api` command
* Add test to ensure number of elements on functions `GetAroundMe` and `GetAroundScore`