### PR TITLE
Add step to test podium with cluster on CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,6 +57,12 @@ jobs:
   
   test-cluster:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:4
+        options: '--health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5'
+        ports:
+          - '6379:6379'
     steps:
       - name: Instantiate redis cluster
         uses: vishnudxb/redis-cluster@1.0.5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -87,10 +87,22 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
-      - name: Setup env
-        run: make setup
       - name: Test
-        run: make compose-test
+        run: make test
+        env:
+          PODIUM_REDIS_CLUSTERENABLED: true
+      - name: Coverage
+        run: make coverage
+        env:
+          PODIUM_REDIS_CLUSTERENABLED: true
+      - name: Install goveralls
+        env:
+          GO111MODULE: off
+        run: go get github.com/mattn/goveralls
+      - name: Send coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goveralls -coverprofile _build/test-coverage-all.out -service=github
 
   build_and_deploy_podium:
     needs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -93,7 +93,8 @@ jobs:
         run: make compose-test
   build_and_deploy_podium:
     needs:
-      - tests
+      - test-standalone
+      - test-cluster
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'leaderboard/')
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,6 +91,7 @@ jobs:
         run: make setup
       - name: Test
         run: make compose-test
+
   build_and_deploy_podium:
     needs:
       - test-standalone
@@ -131,11 +132,13 @@ jobs:
           file: ./build/Dockerfile
           push: true
           tags: tfgco/podium:latest
+
   build_and_deploy_podium_dev:
     runs-on: ubuntu-latest
     if: (!(startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'leaderboard/')))
     needs:
-      - tests
+      - test-standalone
+      - test-cluster
     steps:
       - uses: actions/checkout@v2
       - name: Set env

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,6 +44,8 @@ jobs:
         run: make setup
       - name: Test
         run: make test
+      - name: Test cluster
+        run: make compose-test
       - name: Coverage
         run: make coverage
       - name: Install goveralls

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -87,6 +87,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
+      - name: Setup env
+        run: make setup
       - name: Test
         run: make test
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Test
         run: make test
         env:
-          PODIUM_REDIS_CLUSTERENABLED: true
+          PODIUM_REDIS_CLUSTER_ENABLED: true
       - name: Coverage
         run: make coverage
         env:
-          PODIUM_REDIS_CLUSTERENABLED: true
+          PODIUM_REDIS_CLUSTER_ENABLED: true
       - name: Install goveralls
         env:
           GO111MODULE: off

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,10 +42,10 @@ jobs:
           go-version: 1.15
       - name: Setup env
         run: make setup
-      - name: Test
-        run: make test
       - name: Test cluster
         run: make compose-test
+      - name: Test standalone
+        run: make test
       - name: Coverage
         run: make coverage
       - name: Install goveralls

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@
 name: Podium
 'on': push
 jobs:
-  tests:
+  test-standalone:
     runs-on: ubuntu-latest
     services:
       redis:
@@ -42,9 +42,7 @@ jobs:
           go-version: 1.15
       - name: Setup env
         run: make setup
-      - name: Test cluster
-        run: make compose-test
-      - name: Test standalone
+      - name: Test
         run: make test
       - name: Coverage
         run: make coverage
@@ -56,6 +54,43 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile _build/test-coverage-all.out -service=github
+  
+  test-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Instantiate redis cluster
+        uses: vishnudxb/redis-cluster@1.0.5
+        with:
+          master1-port: 5000
+          master2-port: 5001
+          master3-port: 5002
+          slave1-port: 5003
+          slave2-port: 5004
+          slave3-port: 5005
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - uses: actions/checkout@v2
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+      # Cache go mod cache, used to speedup builds
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Setup env
+        run: make setup
+      - name: Test
+        run: make compose-test
   build_and_deploy_podium:
     needs:
       - tests

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,7 +2,8 @@ healthcheck:
   workingText: WORKING
 
 redis:
-  clusterEnabled: false
+  cluster:
+    enabled: false
   addrs: "localhost:5000"
   host: localhost
   port: 6379

--- a/deployments/docker-compose-model.yaml
+++ b/deployments/docker-compose-model.yaml
@@ -68,6 +68,7 @@ services:
       context: ../
       dockerfile: ./build/TestAppDockerfile
     depends_on:
+      - redis-standalone
       - redis-node-0
       - redis-node-1
       - redis-node-2

--- a/deployments/docker-compose-model.yaml
+++ b/deployments/docker-compose-model.yaml
@@ -68,7 +68,6 @@ services:
       context: ../
       dockerfile: ./build/TestAppDockerfile
     depends_on:
-      - redis-standalone
       - redis-node-0
       - redis-node-1
       - redis-node-2

--- a/leaderboard/database/redis.go
+++ b/leaderboard/database/redis.go
@@ -284,7 +284,10 @@ func (r *Redis) SetMembersTTL(ctx context.Context, leaderboard string, databaseM
 		return NewGeneralError(err.Error())
 	}
 
-	r.Redis.SAdd(ctx, ExpirationSet, expirationKey)
+	err = r.Redis.SAdd(ctx, ExpirationSet, expirationKey)
+	if err != nil {
+		return NewGeneralError(err.Error())
+	}
 
 	return nil
 }

--- a/leaderboard/database/redis_expiration.go
+++ b/leaderboard/database/redis_expiration.go
@@ -39,7 +39,7 @@ func (r *Redis) GetMembersToExpire(ctx context.Context, leaderboard string, amou
 		return nil, NewGeneralError(err.Error())
 	}
 
-	unixTimestamp := maxTime.UTC().Unix()
+	unixTimestamp := maxTime.Unix()
 
 	members, err := r.Redis.ZRangeByScore(ctx, expirationSet, "-inf", strconv.FormatInt(unixTimestamp, 10), 0, int64(amount))
 	if err != nil {

--- a/leaderboard/database/redis_test.go
+++ b/leaderboard/database/redis_test.go
@@ -751,8 +751,16 @@ var _ = Describe("Redis Database", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Should return GeneralError if redis return in error", func() {
+		It("Should return GeneralError if redis ZAdd return in error", func() {
 			mock.EXPECT().ZAdd(gomock.Any(), gomock.Eq(leaderboardTTL), gomock.Eq(redisMembers[0]), gomock.Eq(redisMembers[1])).Return(fmt.Errorf("New redis error"))
+
+			err := redisDatabase.SetMembersTTL(context.Background(), leaderboard, databaseMembers)
+			Expect(err).To(Equal(database.NewGeneralError("New redis error")))
+		})
+
+		It("Should return GeneralError if redis SAdd return in error", func() {
+			mock.EXPECT().ZAdd(gomock.Any(), gomock.Eq(leaderboardTTL), gomock.Eq(redisMembers[0]), gomock.Eq(redisMembers[1])).Return(nil)
+			mock.EXPECT().SAdd(gomock.Any(), gomock.Eq(database.ExpirationSet), gomock.Eq(leaderboardTTL)).Return(fmt.Errorf("New redis error"))
 
 			err := redisDatabase.SetMembersTTL(context.Background(), leaderboard, databaseMembers)
 			Expect(err).To(Equal(database.NewGeneralError("New redis error")))

--- a/worker/expiration_worker.go
+++ b/worker/expiration_worker.go
@@ -100,7 +100,7 @@ func (w *ExpirationWorker) configure() error {
 	w.stop = make(chan bool, 1)
 
 	database := database.NewRedisDatabase(database.RedisOptions{
-		ClusterEnabled: w.Config.GetBool("redis.clusterEnabled"),
+		ClusterEnabled: w.Config.GetBool("redis.cluster.enabled"),
 		Addrs:          w.Config.GetStringSlice("redis.addrs"),
 		Host:           w.Config.GetString("redis.host"),
 		Port:           w.Config.GetInt("redis.port"),

--- a/worker/expiration_worker.go
+++ b/worker/expiration_worker.go
@@ -176,7 +176,7 @@ func (w *ExpirationWorker) expireMembers(resultsChan chan<- []*ExpirationResult,
 
 	result := []*ExpirationResult{}
 	for _, leaderboard := range leaderboardExpirations {
-		members, err := w.Database.GetMembersToExpire(context.Background(), leaderboard, w.ExpirationLimitPerRun, time.Now())
+		members, err := w.Database.GetMembersToExpire(context.Background(), leaderboard, w.ExpirationLimitPerRun, time.Now().UTC())
 		if err != nil {
 			if _, ok := err.(*database.LeaderboardWithoutMemberToExpireError); ok {
 				err = w.Database.RemoveLeaderboardFromExpireList(context.Background(), leaderboard)

--- a/worker/expiration_worker_test.go
+++ b/worker/expiration_worker_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Scores Expirer Worker", func() {
 		var err error
 		expirationWorker, err = worker.GetExpirationWorker("../config/test.yaml")
 		redisClient = database.NewRedisDatabase(database.RedisOptions{
-			ClusterEnabled: expirationWorker.Config.GetBool("redis.clusterEnabled"),
+			ClusterEnabled: expirationWorker.Config.GetBool("redis.cluster.enabled"),
 			Addrs:          expirationWorker.Config.GetStringSlice("redis.addrs"),
 			Host:           expirationWorker.Config.GetString("redis.host"),
 			Port:           expirationWorker.Config.GetInt("redis.port"),


### PR DESCRIPTION
Now that Podium support both standalone and cluster Redis instances, it is necessary for our CI to check if any change is compliant with both implementations. 

This PR adds a new job in our CI to test the implementation against the cluster to ensure nothing breaks. This new job will run in parallel while the standalone test is running on another job.