### PR TITLE
Avoid call SREM without member to exclude on worker

### DIFF
--- a/worker/expiration_worker_test.go
+++ b/worker/expiration_worker_test.go
@@ -141,7 +141,6 @@ var _ = Describe("Scores Expirer Worker", func() {
 		members, err := redisClient.SMembers(context.Background(), database.ExpirationSet)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(members)).To(Equal(1))
-		fmt.Printf("%+v", members)
 
 		err = redisClient.Exists(context.Background(), redisLBExpirationKey)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### Why
When we put POdium `10.1.1` on prod the worker starts to throw an error on `SREM` without members to exclude. This is happening because currently, the number of members to expire is not checked. This PR proposes to check this and refactor expireMembers on `expiration_worker` to improve code quality.

### What was done
- Add conditional call to ExpireMembers on expiration_worker