### PR TITLE
Added start command and updated Go version to 1.17 in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright © 2019 Top Free Games <backend@tfgco.com>
 
-FROM golang:1.16.3-alpine as build
+FROM golang:1.17-alpine as build
 
 MAINTAINER TFG Co <backend@tfgco.com>
 
@@ -21,4 +21,4 @@ COPY --from=build /podium/config/default.yaml /default.yaml
 
 RUN chmod +x /podium
 
-ENTRYPOINT ["/podium", "-c", "/default.yaml"]
+ENTRYPOINT ["/podium", "-c", "/default.yaml", "start"]


### PR DESCRIPTION
This fixes the container not being able to start. You should probably push this to your Docker Hub, too.

I have set up a version on mine for the time being for whoever is going to need it: https://hub.docker.com/r/tanis2000/podium